### PR TITLE
Add prodigy_to_tsv command

### DIFF
--- a/tests/prodigy/test_prodigy_to_tsv.py
+++ b/tests/prodigy/test_prodigy_to_tsv.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import os
+import sys
+
+import pytest
+from wellcomeml.prodigy.prodigy_to_tsv import TokenLabelPairs
+
+
+def test_yield_token_label_pair():
+
+    doc = dict()
+
+    doc["spans"] = [
+        {"start": 0, "end": 0, "token_start": 0, "token_end": 0, "label": "a"},
+        {"start": 1, "end": 1, "token_start": 1, "token_end": 1, "label": "b"},
+        {"start": 2, "end": 2, "token_start": 2, "token_end": 2, "label": "c"},
+        {"start": 3, "end": 3, "token_start": 3, "token_end": 3, "label": "d"},
+        {"start": 4, "end": 4, "token_start": 4, "token_end": 4, "label": "e"},
+        {"start": 5, "end": 5, "token_start": 5, "token_end": 5, "label": "f"},
+        {"start": 6, "end": 6, "token_start": 6, "token_end": 6, "label": "g"},
+    ]
+
+    doc["tokens"] = [
+        {"text": "A", "start": 0, "end": 0, "id": 0},
+        {"text": "B", "start": 1, "end": 1, "id": 1},
+        {"text": "C", "start": 2, "end": 2, "id": 2},
+        {"text": "D", "start": 3, "end": 3, "id": 3},
+        {"text": "E", "start": 4, "end": 4, "id": 4},
+        {"text": "F", "start": 5, "end": 5, "id": 5},
+        {"text": "G", "start": 6, "end": 6, "id": 6},
+    ]
+
+    out = [
+        ("A", "a"),
+        ("B", "b"),
+        ("C", "c"),
+        ("D", "d"),
+        ("E", "e"),
+        ("F", "f"),
+        ("G", "g"),
+        (None, None),
+    ]
+
+    tlp = TokenLabelPairs(line_limit=73, respect_line_endings=True)
+    after = list(tlp.yield_token_label_pair(doc))
+
+    assert out == after
+
+
+def test_TokenLabelPairs():
+
+    doc = dict()
+
+    doc["spans"] = [
+        {"start": 0, "end": 0, "token_start": 0, "token_end": 0, "label": "a"},
+        {"start": 1, "end": 1, "token_start": 1, "token_end": 1, "label": "b"},
+        {"start": 2, "end": 2, "token_start": 2, "token_end": 2, "label": "c"},
+        {"start": 3, "end": 3, "token_start": 3, "token_end": 3, "label": "d"},
+        {"start": 4, "end": 4, "token_start": 4, "token_end": 4, "label": "e"},
+        {"start": 5, "end": 5, "token_start": 5, "token_end": 5, "label": "f"},
+        {"start": 6, "end": 6, "token_start": 6, "token_end": 6, "label": "g"},
+    ]
+
+    doc["tokens"] = [
+        {"text": "A", "start": 0, "end": 0, "id": 0},
+        {"text": "B", "start": 1, "end": 1, "id": 1},
+        {"text": "C", "start": 2, "end": 2, "id": 2},
+        {"text": "D", "start": 3, "end": 3, "id": 3},
+        {"text": "E", "start": 4, "end": 4, "id": 4},
+        {"text": "F", "start": 5, "end": 5, "id": 5},
+        {"text": "G", "start": 6, "end": 6, "id": 6},
+    ]
+
+    docs = [doc, doc, doc]
+
+    out = [
+        ("A", "a"),
+        ("B", "b"),
+        ("C", "c"),
+        ("D", "d"),
+        ("E", "e"),
+        ("F", "f"),
+        ("G", "g"),
+        ("A", "a"),
+        ("B", "b"),
+        ("C", "c"),
+        ("D", "d"),
+        ("E", "e"),
+        ("F", "f"),
+        ("G", "g"),
+        ("A", "a"),
+        ("B", "b"),
+        ("C", "c"),
+        ("D", "d"),
+        ("E", "e"),
+        ("F", "f"),
+        ("G", "g"),
+    ]
+
+    tlp = TokenLabelPairs(line_limit=73, respect_line_endings=True,
+        respect_doc_endings=False)
+    after = tlp.run(docs)
+
+    assert after == out
+
+
+def test_TokenLabelPairs_works_on_unlabelled():
+
+    doc = dict()
+
+    doc["tokens"] = [
+        {"text": "A", "start": 0, "end": 0, "id": 0},
+        {"text": "B", "start": 1, "end": 1, "id": 1},
+        {"text": "C", "start": 2, "end": 2, "id": 2},
+        {"text": "D", "start": 3, "end": 3, "id": 3},
+        {"text": "E", "start": 4, "end": 4, "id": 4},
+        {"text": "F", "start": 5, "end": 5, "id": 5},
+        {"text": "G", "start": 6, "end": 6, "id": 6},
+    ]
+
+    docs = [doc, doc, doc]
+
+    out = [
+        ("A", None),
+        ("B", None),
+        ("C", None),
+        ("D", None),
+        ("E", None),
+        ("F", None),
+        ("G", None),
+        (None, None),
+        ("A", None),
+        ("B", None),
+        ("C", None),
+        ("D", None),
+        ("E", None),
+        ("F", None),
+        ("G", None),
+        (None, None),
+        ("A", None),
+        ("B", None),
+        ("C", None),
+        ("D", None),
+        ("E", None),
+        ("F", None),
+        ("G", None),
+        (None, None),
+    ]
+
+    tlp = TokenLabelPairs(line_limit=73, respect_line_endings=True)
+    after = tlp.run(docs)
+
+    assert after == out
+
+
+def test_TokenLabelPairs_cleans_whitespace():
+
+    doc = dict()
+
+    doc["tokens"] = [
+        {"text": "A ", "start": 0, "end": 0, "id": 0},
+        {"text": "B  ", "start": 1, "end": 1, "id": 1},
+        {"text": "C   ", "start": 2, "end": 2, "id": 2},
+        {"text": "D\t", "start": 3, "end": 3, "id": 3},
+        {"text": "E\t\t", "start": 4, "end": 4, "id": 4},
+        {"text": "F\t\t \t", "start": 5, "end": 5, "id": 5},
+        {"text": "G \t \t \t \t", "start": 6, "end": 6, "id": 6},
+        {"text": "\n", "start": 7, "end": 7, "id": 7},
+        {"text": "\n ", "start": 8, "end": 8, "id": 8},
+        {"text": "\n\t \t \t \t", "start": 9, "end": 6, "id": 9},
+    ]
+
+    docs = [doc]
+
+    out = [
+        ("A", None),
+        ("B", None),
+        ("C", None),
+        ("D", None),
+        ("E", None),
+        ("F", None),
+        ("G", None),
+        (None, None),
+        (None, None),
+        (None, None),
+    ]
+
+    tlp = TokenLabelPairs(line_limit=73, respect_line_endings=True)
+    after = tlp.run(docs)
+
+    assert after == out
+
+
+def test_TokenLabelPairs_retains_line_endings():
+    """
+    Rodrigues et al. retain the line endings as they appear in the text, meaning
+    that on average a line is very short.
+    """
+
+    doc = dict()
+
+    doc["tokens"] = [
+        {"text": "\n", "start": 0, "end": 0, "id": 0},
+        {"text": "\n", "start": 1, "end": 1, "id": 1},
+        {"text": "\n", "start": 2, "end": 2, "id": 2},
+        {"text": "\n", "start": 3, "end": 3, "id": 3},
+    ]
+
+    docs = [doc]
+
+    out = [
+        (None, None),
+        (None, None),
+        (None, None),
+        (None, None),
+    ]
+
+    tlp = TokenLabelPairs(respect_line_endings=True)
+    after = tlp.run(docs)
+
+    assert after == out
+
+
+def test_TokenLabelPairs_ignores_line_endings():
+
+    doc = dict()
+
+    doc["tokens"] = [
+        {"text": "a", "start": 0, "end": 0, "id": 0},
+        {"text": "b", "start": 1, "end": 1, "id": 1},
+        {"text": "c", "start": 2, "end": 2, "id": 2},
+        {"text": "d", "start": 3, "end": 3, "id": 3},
+    ]
+
+    docs = [doc]
+
+    out = [
+        ("a", None),
+        ("b", None),
+        (None, None),
+        ("c", None),
+        ("d", None),
+        (None, None),
+    ]
+
+    tlp = TokenLabelPairs(line_limit=2, respect_line_endings=False)
+    after = tlp.run(docs)
+
+    assert after == out
+
+def test_TokenLabelPairs_respects_ignores_doc_endings():
+
+    doc = dict()
+
+    doc["tokens"] = [
+        {"text": "A", "start": 0, "end": 0, "id": 0},
+        {"text": "B", "start": 1, "end": 1, "id": 1},
+        {"text": "C", "start": 2, "end": 2, "id": 2},
+        {"text": "D", "start": 3, "end": 3, "id": 3},
+        {"text": "E", "start": 4, "end": 4, "id": 4},
+        {"text": "F", "start": 5, "end": 5, "id": 5},
+        {"text": "G", "start": 6, "end": 6, "id": 6},
+    ]
+
+    docs = [doc, doc, doc]
+
+    out = [
+        ("A", None),
+        ("B", None),
+        ("C", None),
+        ("D", None),
+        ("E", None),
+        ("F", None),
+        ("G", None),
+        ("A", None),
+        ("B", None),
+        ("C", None),
+        ("D", None),
+        ("E", None),
+        ("F", None),
+        ("G", None),
+        ("A", None),
+        ("B", None),
+        ("C", None),
+        ("D", None),
+        ("E", None),
+        ("F", None),
+        ("G", None),
+    ]
+
+    tlp = TokenLabelPairs(line_limit=73, respect_line_endings=False, respect_doc_endings=False)
+    after = tlp.run(docs)
+
+    assert after == out
+

--- a/wellcomeml/__main__.py
+++ b/wellcomeml/__main__.py
@@ -1,0 +1,31 @@
+# coding: utf8
+
+"""
+Modified from https://github.com/explosion/spaCy/blob/master/spacy/__main__.py
+
+Allows CLI functions defined by plac (or argparse) to be called using the
+following syntax:
+
+`python -m wellcomeml <command>`
+"""
+
+if __name__ == "__main__":
+    import plac
+    import sys
+    from wasabi import msg
+    from .prodigy.prodigy_to_tsv import prodigy_to_tsv
+
+    commands = {
+        "prodigy_to_tsv": prodigy_to_tsv,
+    }
+
+    if len(sys.argv) == 1:
+        msg.info("Available commands", ", ".join(commands), exits=1)
+    command = sys.argv.pop(1)
+    sys.argv[0] = "wellcomeml %s" % command
+
+    if command in commands:
+        plac.call(commands[command], sys.argv[1:])
+    else:
+        available = "Available: {}".format(", ".join(commands))
+        msg.fail("Unknown command: {}".format(command), available, exits=1)

--- a/wellcomeml/prodigy/prodigy_to_tsv.py
+++ b/wellcomeml/prodigy/prodigy_to_tsv.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+"""
+Class used in scripts/prodigy_to_tsv.py which converts token annotated jsonl
+files to tab-separated-values files for use in the deep reference parser
+"""
+
+import csv
+import re
+
+import numpy as np
+import plac
+
+from ..io import read_jsonl
+
+from ..logger import logger
+
+
+class TokenLabelPairs:
+    """
+    Convert prodigy format docs or list of lists into tuples of (token, label).
+    """
+
+    def __init__(self, line_limit=73, respect_line_endings=True, respect_doc_endings=True):
+        """
+        Args:
+            line_limit(int): Maximum number of tokens allowed per training
+                example. If you are planning to use this data for making
+                predictions, then this should correspond to the max_words
+                attribute for the DeepReferenceParser class used to train the
+                model.
+            respect_line_endings(bool): If true, line endings appearing in the
+                text will be respected, leading to much shorter line lengths
+                usually <10. Typically this results in a much worser performing
+                model, but follows the convention set by Rodrigues et al.
+            respect_doc_endings(bool): If true, a line ending is added at the
+                end of each document. If false, then the end of a document flows
+                into the beginning of the next document.
+        """
+
+        self.line_count = 0
+        self.line_lengths = []
+        self.line_limit = line_limit
+        self.respect_doc_endings = respect_doc_endings
+        self.respect_line_endings = respect_line_endings
+
+    def run(self, docs):
+        """
+        """
+
+        out = []
+
+        for doc in docs:
+            out.extend(self.yield_token_label_pair(doc))
+
+        self.stats(out)
+
+        return out
+
+
+    def stats(self, out):
+
+        avg_line_len = np.round(np.mean(self.line_lengths), 2)
+
+        logger.debug("Returning %s examples", self.line_count)
+        logger.debug("Average line length: %s", avg_line_len)
+
+    def yield_token_label_pair(self, doc, lists=False):
+        """
+        Expect list of jsons loaded from a jsonl
+
+        Args:
+            doc (dict): Document in prodigy format or list of lists
+            lists (bool): Expect a list of lists rather than a prodigy format
+                dict?
+
+        NOTE: Makes the assumption that every token has been labelled in spans. This
+        assumption will be true if the data has been labelled with prodigy, then
+        spans covering entire references have been converted to token spans. OR that
+        there are no spans at all, and this is being used to prepare data for
+        prediction.
+        """
+
+        # Ensure that spans and tokens are sorted (they should be)
+
+        if lists:
+            tokens = doc
+        else:
+            tokens = sorted(doc["tokens"], key=lambda k: k["id"])
+
+        # For prediction, documents may not yet have spans. If they do, sort
+        # them too based on token_start which is equivalent to id in
+        # doc["tokens"].
+
+        spans = doc.get("spans")
+
+        if spans:
+            spans = sorted(doc["spans"], key=lambda k: k["token_start"])
+
+        # Set a token counter that is used to limit the number of tokens to
+        # line_limit.
+
+        token_counter = int(0)
+
+        doc_len = len(tokens)
+
+        for i, token in enumerate(tokens, 1):
+
+            label = None
+
+            # For case when tokens have been labelled with spans (for training
+            # data).
+
+            if spans:
+                # Need to remove one from index as it starts at 1!
+                label = spans[i - 1].get("label")
+
+            text = token["text"]
+
+            # If the token is empty even if it has been labelled, pass it
+
+            if text == "":
+
+                pass
+
+            # If the token is a newline (and possibly other characters) and we want
+            # to respect line endings in the text, then yield a (None, None) tuple
+            # which will be converted to a blank line when the resulting tsv file
+            # is read.
+
+            elif re.search(r"\n", text) and self.respect_line_endings:
+
+                # Is it blank after whitespace is removed?
+
+                if text.strip() == "":
+
+                    yield (None, None)
+
+                self.line_lengths.append(token_counter)
+                self.line_count += 1
+
+                token_counter = 0
+
+            elif token_counter == self.line_limit:
+
+                # Yield None, None to signify a line ending, then yield the next
+                # token.
+
+                yield (None, None)
+                yield (text.strip(), label)
+
+                # Set to one to account for the first token being added.
+
+                self.line_lengths.append(token_counter)
+                self.line_count += 1
+
+                token_counter = 1
+
+            elif i == doc_len and self.respect_doc_endings:
+
+                # Case when the end of the document has been reached, but it is
+                # less than self.lime_limit. This assumes that we want to retain
+                # a line ending which denotes the end of a document, and the
+                # start of new one.
+
+                yield (text.strip(), label)
+                yield (None, None)
+
+                self.line_lengths.append(token_counter)
+                self.line_count += 1
+
+            else:
+
+                # Returned the stripped label.
+
+                yield (text.strip(), label)
+
+                token_counter += 1
+
+
+@plac.annotations(
+    input_file=(
+        "Path to jsonl file containing prodigy docs.",
+        "positional",
+        None,
+        str
+    ),
+    output_file=(
+        "Path to output tsv file.",
+        "positional",
+        None,
+        str
+    )
+)
+def prodigy_to_tsv(input_file, output_file):
+    """
+    Convert token annotated jsonl to token annotated tsv ready for use in the
+    Rodrigues model.
+    """
+
+    annotated_data = read_jsonl(input_file)
+
+    logger.info("Loaded %s prodigy docs", len(annotated_data))
+
+    tlp = TokenLabelPairs()
+    token_label_pairs = list(tlp.run(annotated_data))
+
+    with open(output_file, 'w') as fb:
+        writer = csv.writer(fb, delimiter="\t")
+        # Write DOCSTART and a blank line
+        writer.writerows([("DOCSTART", None), (None, None)])
+        writer.writerows(token_label_pairs)
+
+    logger.info("Wrote %s token/label pairs to %s", len(token_label_pairs),
+        output_file)
+


### PR DESCRIPTION
Similar to https://github.com/wellcometrust/WellcomeML/pull/12 (though not depending on it) this PR adds the  `prodigy_to_tsv` command which allows you to convert prodigy format jsonl files into tab separated values (tsv) files with each token and annotation represented on one line: e.g.:

```
11	o
.	o
	o
Betel	b-r
-	i-r
quid	i-r
and	i-r
areca	i-r
-	i-r
nut	i-r

```