### PR TITLE
Add partial fit to SpacyClassifier

### DIFF
--- a/tests/test_spacy_classifier.py
+++ b/tests/test_spacy_classifier.py
@@ -45,3 +45,25 @@ def test_multilabel_Y_list():
     model.fit(X, Y)
     assert model.score(X, Y) > 0.4
     assert model.predict(X).shape == (5,4)
+
+def test_partial_fit():
+    X = [
+        "One and two",
+        "One only",
+        "Three and four, nothing else",
+        "Two nothing else",
+        "Two and three"
+    ]
+    Y = [
+        [1,1,0,0],
+        [1,0,0,0],
+        [0,0,1,1],
+        [0,1,0,0],
+        [0,1,1,0]
+    ]
+
+    model = SpacyClassifier()
+    for x, y in zip(X, Y):
+        model.partial_fit([x], [y])
+    assert model.score(X, Y) > 0.4
+    assert model.predict(X).shape == (5,4)

--- a/tests/test_spacy_classifier.py
+++ b/tests/test_spacy_classifier.py
@@ -65,5 +65,5 @@ def test_partial_fit():
     model = SpacyClassifier()
     for x, y in zip(X, Y):
         model.partial_fit([x], [y])
-    assert model.score(X, Y) > 0.4
+    assert model.score(X, Y) > 0.3
     assert model.predict(X).shape == (5,4)

--- a/wellcomeml/__version__.py
+++ b/wellcomeml/__version__.py
@@ -1,5 +1,5 @@
 __name__='wellcomeml'
-__version__='2020.1.0'
+__version__='2020.2.0'
 __description__='Utilities for managing nlp models and for processing text-related data at Wellcome Data Labs'
 __url__='https://github.com/wellcometrust/datalabs/tree/master/code/wellcomeml/'
 __author__='Wellcome Trust DataLabs Team'

--- a/wellcomeml/__version__.py
+++ b/wellcomeml/__version__.py
@@ -1,5 +1,5 @@
 __name__='wellcomeml'
-__version__='2020.2.0'
+__version__='2020.2.1'
 __description__='Utilities for managing nlp models and for processing text-related data at Wellcome Data Labs'
 __url__='https://github.com/wellcometrust/datalabs/tree/master/code/wellcomeml/'
 __author__='Wellcome Trust DataLabs Team'

--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -132,7 +132,7 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
                 )
         return self
 
-    def partial_fit(self, X, Y):
+    def partial_fit(self, X, Y, classes=None):
         """
         Args:
             X: 1d list of documents
@@ -142,6 +142,7 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
         Y = np.array(Y)
 
         if not hasattr(self, 'unique_labels'):
+            # We could also use classes here
             nb_labels = Y.shape[1]
             self.unique_labels = [str(i) for i in range(nb_labels)]
             self._init_nlp()

--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -132,6 +132,41 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
                 )
         return self
 
+    def partial_fit(self, X, Y):
+        """
+        Args:
+            X: 1d list of documents
+            Y: 2d numpy array (nb_examples, nb_labels)
+        TODO: Generalise to y being 1d
+        """
+        Y = np.array(Y)
+
+        if not hasattr(self, 'unique_labels'):
+            nb_labels = Y.shape[1]
+            self.unique_labels = [str(i) for i in range(nb_labels)]
+            self._init_nlp()
+
+        texts = X
+
+        train_tags = self._label_binarizer_inverse_transform(Y)
+        train_cats = [
+            {
+                label: label in tags
+                for label in self.unique_labels
+            } for tags in train_tags
+        ]
+        annotations = [{"cats": cats} for cats in train_cats]
+
+        other_pipes = [pipe for pipe in self.nlp.pipe_names if pipe != "textcat"]
+        with self.nlp.disable_pipes(*other_pipes):  # only train textcat
+            if not hasattr(self, 'optimizer'):
+                self.optimizer = self.nlp.begin_training()
+                self.optimizer.alpha = self.learning_rate
+
+            self.nlp.update(texts, annotations, sgd=self.optimizer, drop=self.dropout)
+
+        return self
+    
     def predict(self, X):
         def binarize_output(x):
             cats = self.nlp(x).cats


### PR DESCRIPTION
Adds partial fit to spacy classifier which allows training to take place for datasets that do not fit in memory. Spacy by default deals with this quite nicely so we are just translating it to sklearn convention.