### PR TITLE
Add average of 4 last layers and tests to bert embeddings

### DIFF
--- a/tests/test_bert_vectorizer.py
+++ b/tests/test_bert_vectorizer.py
@@ -2,12 +2,22 @@
 
 from wellcomeml.ml import bert_vectorizer
 
+EMBEDDING_TYPES = [
+    "mean_second_to_last",
+    "mean_last",
+    "sum_last",
+    "mean_last_four",
+    "pooler"
+]
+
+
 def test_embed_one_sentence():
     X = ["This is a sentence"]
 
-    vec = bert_vectorizer.BertVectorizer()
-    X_embed = vec.fit_transform(X)
-    assert(X_embed.shape == (1, 768))
+    for embedding in EMBEDDING_TYPES:
+        vec = bert_vectorizer.BertVectorizer(sentence_embedding=embedding)
+        X_embed = vec.fit_transform(X)
+        assert(X_embed.shape == (1, 768))
 
 def test_embed_two_sentences():
     X = [
@@ -15,23 +25,24 @@ def test_embed_two_sentences():
         "This is another one"
     ]
 
-    vec = bert_vectorizer.BertVectorizer()
-    X_embed = vec.fit_transform(X)
-    assert(X_embed.shape == (2, 768))
+    for embedding in EMBEDDING_TYPES:
+        vec = bert_vectorizer.BertVectorizer(sentence_embedding=embedding)
+        X_embed = vec.fit_transform(X)
+        assert(X_embed.shape == (2, 768))
 
 def test_embed_long_sentence():
     X = ["This is a sentence"*100]
 
-    vec = bert_vectorizer.BertVectorizer()
-    X_embed = vec.fit_transform(X)
-    assert(X_embed.shape == (1, 768))
+    for embedding in EMBEDDING_TYPES:
+        vec = bert_vectorizer.BertVectorizer(sentence_embedding=embedding)
+        X_embed = vec.fit_transform(X)
+        assert(X_embed.shape == (1, 768))
 
 
 def test_embed_scibert():
     X = ["This is a sentence"*100]
-
-    vec = bert_vectorizer.BertVectorizer(pretrained='scibert')
-    X_embed = vec.fit_transform(X)
-
-    # Tests if loads correctly
-    assert(X_embed.shape == (1, 768))
+    for embedding in EMBEDDING_TYPES:
+        vec = bert_vectorizer.BertVectorizer(pretrained='scibert',
+                                             sentence_embedding=embedding)
+        X_embed = vec.fit_transform(X)
+        assert(X_embed.shape == (1, 768))

--- a/wellcomeml/ml/bert_vectorizer.py
+++ b/wellcomeml/ml/bert_vectorizer.py
@@ -21,6 +21,16 @@ from wellcomeml.logger import logger
 
 class BertVectorizer(BaseEstimator, TransformerMixin):
     def __init__(self, pretrained='bert', sentence_embedding='mean_second_to_last'):
+        """
+        Bert vectorizer parameters
+
+        Args:
+            pretrained: A pre-trained model name. Currently 'bert' or 'scibert'
+            sentence_embedding: How to embedd a sentence using bert's layers.
+            Current options:
+            'mean_second_to_last', 'mean_last', 'sum_last' or 'mean_last_four'
+            If unset, returns the pooler layer (embedding for the token [CLS])
+        """
         self.pretrained = pretrained
         self.sentence_embedding = sentence_embedding
 

--- a/wellcomeml/ml/bert_vectorizer.py
+++ b/wellcomeml/ml/bert_vectorizer.py
@@ -29,7 +29,8 @@ class BertVectorizer(BaseEstimator, TransformerMixin):
             sentence_embedding: How to embedd a sentence using bert's layers.
             Current options:
             'mean_second_to_last', 'mean_last', 'sum_last' or 'mean_last_four'
-            If unset, returns the pooler layer (embedding for the token [CLS])
+            Default: `mean_second_to_last`. If a valid option is not set,
+            returns the pooler layer (embedding for the token [CLS])
         """
         self.pretrained = pretrained
         self.sentence_embedding = sentence_embedding

--- a/wellcomeml/ml/bert_vectorizer.py
+++ b/wellcomeml/ml/bert_vectorizer.py
@@ -47,9 +47,12 @@ class BertVectorizer(BaseEstimator, TransformerMixin):
             embedded_x = last_layer.mean(dim=1)
         elif self.sentence_embedding == 'sum_last':
             embedded_x = last_layer.sum(dim=1)
+        elif self.sentence_embedding == "mean_last_four":
+            embedded_x = torch.stack(output[2][-4:]).mean(dim=0).mean(dim=1)
         else:
-            # 'last_cls'
-            embedded_x = last_layer[0, :]
+            # Else gives the embbedding for the pooler layer. This can be, for
+            # example, fed into a softmax classifier
+            embedded_x = output[1]
 
         return embedded_x.cpu().numpy().flatten()
 


### PR DESCRIPTION
**Description**
 - [x] Adds the average of the last 4 hidden layers of Bert as a possible embedding.
 - [x] Updates tests to consider all embedding types
- [x] Changes the fallback embedding option to the embedding of `[CLS]`

Fixes https://github.com/wellcometrust/WellcomeML/issues/7