### PR TITLE
Optimise spacy memory consumption

### DIFF
--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -92,13 +92,12 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
         
         def yield_train_data(X_train, Y_train):
             for x, y in zip(X_train, Y_train):
-                tags = self._label_binarizer_inverse_transform(y)
+                tags = self._label_binarizer_inverse_transform([y])[0]
                 cats = {
                     label: label in tags
                     for label in self.unique_labels
                 }
-                yield (x, cats)
-        train_data = yield_train_data(X_train, Y_train)
+                yield (x, {"cats": cats})
 
         # start of problem        
         #train_texts = X_train
@@ -125,7 +124,8 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
             for i in range(n_iter):
                 losses = {}
                 # batch up the examples using spaCy's minibatch
-                random.shuffle(train_data)
+                train_data = yield_train_data(X_train, Y_train)
+                #random.shuffle(train_data)
                 batches = minibatch(train_data, size=batch_sizes)
                 for batch in batches:
                     texts, annotations = zip(*batch)


### PR DESCRIPTION
Optimise use of memory in SpacyClassifier by
* deleting the passed data X, Y which then become X_train, Y_train, X_test, Y_test
* creating a generator that yields the transformed data that spacy needs on demand instead of materialising them in memory
* moves shuffling into X_train, Y_train since the data that spacy received are not in memory to be shuffled