### PR TITLE
Add ability to handle sparse binarizer

### DIFF
--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -10,6 +10,7 @@ from sklearn.metrics import f1_score, precision_score, recall_score
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import precision_recall_fscore_support
+from scipy.sparse import csr_matrix
 import numpy as np
 import spacy
 import torch
@@ -66,6 +67,9 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
         "Transforms Y matrix to labels which are the non zero indices"
         data = []
         for row in Y_train:
+            if type(row) is csr_matrix:
+                row = row.todense()
+                row = np.squeeze(np.asarray(row))
             row_data = [str(i) for i, item in enumerate(row) if item]
             data.append(row_data)
         # Do we need to convert to numpy?
@@ -78,7 +82,8 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
             Y: 2d numpy array (nb_examples, nb_labels)
         TODO: Generalise to y being 1d
         """
-        Y = np.array(Y)
+        if type(Y) == list:
+            Y = np.array(Y)
 
         X_train, X_test, Y_train, Y_test = train_test_split(
             X, Y, random_state=42


### PR DESCRIPTION
Turns out that working with a sparse label binarizer makes a big difference in terms of memory. To make this happen for the spacy classifier we need
* to convert Y to numpy array only when Y is a list, otherwise if it is a sparse matrix it destroys it
* to make Y dense when converting to labels for spacy to learn internally

**WellcomeML release**
A couple of changes have been accumulated so we should release a new version as @aCampello suggested but before we do so I suggest we propagate them in BertClassifier as they also apply there. I will do that in a separate PR tomorrow.