### PR TITLE
Add exclusive classes param in SpacyClassifier

### DIFF
--- a/wellcomeml/ml/bert_classifier.py
+++ b/wellcomeml/ml/bert_classifier.py
@@ -126,7 +126,7 @@ class BertClassifier(BaseEstimator, ClassifierMixin):
                     p, r, f1, _ = precision_recall_fscore_support(Y_test, Y_test_pred, average='micro')
                 loss = losses['trf_textcat']
                 logger.info(
-                    "{0:2d}\t{1:.3f}\t{2:.3f}\t{3:.3f}\t{4:.3f}".format(
+                    "{0:5d}\t{1:.3f}\t{2:.3f}\t{3:.3f}\t{4:.3f}".format(
                         i,
                         loss,
                         p,

--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -29,6 +29,25 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
                  batch_size=8, learning_rate=0.001,
                  dropout=0.1, shuffle=True, architecture="simple_cnn",
                  exclusive_classes=False, pre_trained_vectors_path=None):
+        """
+        Args:
+            threshold: the threshold above of which a label should be assigned.
+                Should take values from 0 to 1. default is 0.5.
+            batch_size: the number of examples that will be given to the optimizer
+                in each update of the parameters. default is 8.
+            dropout: the dropout added to the layers. default is 0.1.
+            learning_rate: the learning rate of the optimizer. default is 0.001.
+            n_iterations: number of iterations on the entire dataset (epochs)
+                default is 5
+            shuffle: whether the example are shuffled before an iterations.
+                default is True
+            architecture: architecture that Spacy uses. can be one of "bow", "simple_cnn"
+                and "ensemble". default is "simple_cnn"
+            exclusive_classes: whether the problem is multilabel and hence has no exclusive_classes
+                or not. default is False thus multilabel.
+            pre_trained_vectors_path: path to pretrained vectors produced by spacy pretrain.
+                default is None
+        """
         self.threshold = threshold
         self.batch_size = batch_size
         self.dropout = dropout

--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -186,13 +186,22 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
 
         texts = X
 
-        train_tags = self._label_binarizer_inverse_transform(Y)
-        train_cats = [
-            {
-                label: label in tags
-                for label in self.unique_labels
-            } for tags in train_tags
-        ]
+        if self.exclusive_classes:
+            train_cats = []
+            for y in Y:
+                cats = {
+                    label: label == y
+                    for label in self.unique_labels
+                }
+                train_cats.append(cats)
+        else:
+            train_tags = self._label_binarizer_inverse_transform(Y)
+            train_cats = [
+                {
+                    label: label in tags
+                    for label in self.unique_labels
+                } for tags in train_tags
+            ]
         annotations = [{"cats": cats} for cats in train_cats]
 
         other_pipes = [pipe for pipe in self.nlp.pipe_names if pipe != "textcat"]

--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -159,7 +159,7 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
                     p, r, f, _ = precision_recall_fscore_support(Y_test, Y_test_pred, average='micro')
                 loss = losses["textcat"]
                 logger.info(
-                    "{0:2d}\t{1:.3f}\t{2:.3f}\t{3:.3f}\t{4:.3f}".format(
+                    "{0:5d}\t{1:.3f}\t{2:.3f}\t{3:.3f}\t{4:.3f}".format(
                         i,
                         loss,
                         p,

--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -86,7 +86,7 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
             Y: 2d numpy array (nb_examples, nb_labels)
         TODO: Generalise to y being 1d
         """
-        if type(Y) == list:
+        if type(Y) in [list, tuple]:
             Y = np.array(Y)
 
         X_train, X_test, Y_train, Y_test = train_test_split(
@@ -96,7 +96,7 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
         del X
         del Y
 
-        if len(Y_train) > 1:
+        if not self.exclusive_classes:
             nb_labels = Y_train.shape[1]
             self.unique_labels = [str(i) for i in range(nb_labels)]
         else:
@@ -106,7 +106,7 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
         
         def yield_train_data(X_train, Y_train):
             for x, y in zip(X_train, Y_train):
-                if len(Y_train) > 1:
+                if not self.exclusive_classes:
                     tags = self._label_binarizer_inverse_transform([y])[0]
                     cats = {
                         label: label in tags

--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -209,10 +209,7 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
         def transform_output(doc):
             cats = doc.cats
             if self.exclusive_classes:
-                out = [
-                    label if cats[label] > self.threshold else 0
-                    for label in self.unique_labels
-                ]
+                out = max(cats.items(), key=lambda x: x[1])[0]
             else:
                 out = [
                     1 if cats[label] > self.threshold else 0


### PR DESCRIPTION
This PR extends SpacyClassifier to work in normal multiclass problems where the classes are exclusive essentially. This came up during firebreak but it was long time in my todo. It turned out to be slightly more complicated than I anticipated but not too much.