### PR TITLE
Add pretrain vectors

### DIFF
--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -28,7 +28,7 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
     def __init__(self, threshold=0.5, n_iterations=5,
                  batch_size=8, learning_rate=0.001,
                  dropout=0.1, shuffle=True, architecture="simple_cnn",
-                 pre_trained_vectors=None):
+                 pre_trained_vectors_path=None):
         self.threshold = threshold
         self.batch_size = batch_size
         self.dropout = dropout
@@ -36,7 +36,7 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
         self.n_iterations=n_iterations
         self.shuffle=shuffle
         self.architecture=architecture
-        self.pre_trained_vectors=pre_trained_vectors
+        self.pre_trained_vectors_path=pre_trained_vectors_path
 
     def _init_nlp(self):
         self.nlp = spacy.blank('en')
@@ -115,8 +115,8 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
             optimizer.alpha = self.learning_rate
             #optimizer.L2 = 1e-4
 
-            if self.pre_trained_vectors:
-                with open(self.pre_trained_vectors, "rb") as f:
+            if self.pre_trained_vectors_path:
+                with open(self.pre_trained_vectors_path, "rb") as f:
                     self.textcat.model.tok2vec.from_bytes(f.read())
             
             logger.info("Training the model...")

--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -114,8 +114,8 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
             #optimizer.L2 = 1e-4
 
             if self.pre_trained_vectors:
-                with open(pre_trained_vectors, "rb") as f:
-                    self.textcat.model.tok2vec.from_bytes(file_.read())
+                with open(self.pre_trained_vectors, "rb") as f:
+                    self.textcat.model.tok2vec.from_bytes(f.read())
             
             logger.info("Training the model...")
             logger.info("{:^5}\t{:^5}\t{:^5}\t{:^5}\t{:^5}".format("ITER", "LOSS", "P", "R", "F"))

--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -112,6 +112,11 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
             optimizer = self.nlp.begin_training()
             optimizer.alpha = self.learning_rate
             #optimizer.L2 = 1e-4
+
+            if self.pre_trained_vectors:
+                with open(pre_trained_vectors, "rb") as f:
+                    self.textcat.model.tok2vec.from_bytes(file_.read())
+            
             logger.info("Training the model...")
             logger.info("{:^5}\t{:^5}\t{:^5}\t{:^5}\t{:^5}".format("ITER", "LOSS", "P", "R", "F"))
             batch_sizes = compounding(4.0, self.batch_size, 1.001)

--- a/wellcomeml/ml/spacy_classifier.py
+++ b/wellcomeml/ml/spacy_classifier.py
@@ -27,7 +27,8 @@ if is_using_gpu:
 class SpacyClassifier(BaseEstimator, ClassifierMixin):
     def __init__(self, threshold=0.5, n_iterations=5,
                  batch_size=8, learning_rate=0.001,
-                 dropout=0.1, shuffle=True, architecture="simple_cnn"):
+                 dropout=0.1, shuffle=True, architecture="simple_cnn",
+                 pre_trained_vectors=None):
         self.threshold = threshold
         self.batch_size = batch_size
         self.dropout = dropout
@@ -35,6 +36,7 @@ class SpacyClassifier(BaseEstimator, ClassifierMixin):
         self.n_iterations=n_iterations
         self.shuffle=shuffle
         self.architecture=architecture
+        self.pre_trained_vectors=pre_trained_vectors
 
     def _init_nlp(self):
         self.nlp = spacy.blank('en')


### PR DESCRIPTION
Adds this new feature of SpaCy https://spacy.io/usage/v2-1#pretraining.

The idea of the feature is to pretrain some vectors in an largest dataset with no labels and use those vectors in the downstream task. It should have the same effect as BERT like transfer learning.