### PR TITLE
Add attention

### DIFF
--- a/wellcomeml/ml/attention.py
+++ b/wellcomeml/ml/attention.py
@@ -1,4 +1,7 @@
+import tensorflow as tf
+
 class SelfAttention(tf.keras.layers.Layer):
+    """https://papers.nips.cc/paper/7181-attention-is-all-you-need.pdf"""
     def __init__(self, attention_dim=20):
         super(SelfAttention, self).__init__()
         self.attention_dim = attention_dim
@@ -9,9 +12,10 @@ class SelfAttention(tf.keras.layers.Layer):
         self.WV = self.add_weight(shape=(input_shape[-1], input_shape[-1]), trainable=True, initializer='uniform')
 
     def call(self, X):
-    	"""
-    	X: (batch_size, sequence_length, embedding_dimension)
-    	"""
+        """
+        In: (batch_size, sequence_length, embedding_dimension)
+        Out: (batch_size, sequence_length, embedding_dimension)
+        """
         Q = tf.matmul(X, self.WQ)
         K = tf.matmul(X, self.WK)
         V = tf.matmul(X, self.WV)
@@ -19,15 +23,35 @@ class SelfAttention(tf.keras.layers.Layer):
         attention_scores = tf.nn.softmax(tf.matmul(Q, tf.transpose(K, perm=[0,2,1])))
         return tf.matmul(attention_scores, V)
 
-class AttentionMatrix(tf.keras.layers.Layer):
+class FeedForwardAttention(tf.keras.layers.Layer):
+    """https://colinraffel.com/publications/iclr2016feed.pdf"""
+    def __init__(self):
+        super(SimpleAttention, self).__init__()
+
+    def build(self, input_shape):
+        self.W = self.add_weight(shape=(input_shape[-1],1), trainable=True, initializer='uniform')
+
+    def call(self, X):
+        """
+        In: (batch_size, sequence_length, embedding_dimension)
+        Out: (batch_size, embedding_dimension)
+        """
+        e = tf.math.tanh(tf.matmul(X, self.W))
+        attention_scores = tf.nn.softmax(e)
+        return tf.matmul(tf.transpose(X, perm=[0,2,1]), attention_scores)
+
+class HierarchicalAttention(tf.keras.layers.Layer):
+    """https://www.aclweb.org/anthology/N16-1174/"""
     def __init__(self):
         super(AttentionMatrix, self).__init__()
     
     def build(self, input_shape):
-        self.attention_matrix = self.add_weight(shape=(input_shape[-2], input_shape[-2]), trainable=True, initializer='uniform')
+        self.attention_matrix = self.add_weight(shape=(input_shape[-1], input_shape[-2]), trainable=True, initializer='uniform')
     
     def call(self, X):
-    	"""
-    	X: (batch_size, sequence_length, embedding_dimension)
-    	"""
-        return tf.matmul(self.attention_matrix, X)
+        """
+        In: (batch_size, sequence_length, embedding_dimension)
+        Out: (batch_size, sequence_length, embedding_dimension)
+        """
+        attention_scores = tf.nn.softmax(tf.math.tanh(tf.matmul(X, self.attention_matrix)))
+        return tf.matmul(attention_scores, X)

--- a/wellcomeml/ml/attention.py
+++ b/wellcomeml/ml/attention.py
@@ -26,7 +26,7 @@ class SelfAttention(tf.keras.layers.Layer):
 class FeedForwardAttention(tf.keras.layers.Layer):
     """https://colinraffel.com/publications/iclr2016feed.pdf"""
     def __init__(self):
-        super(SimpleAttention, self).__init__()
+        super(FeedForwardAttention, self).__init__()
 
     def build(self, input_shape):
         self.W = self.add_weight(shape=(input_shape[-1],1), trainable=True, initializer='uniform')
@@ -43,7 +43,7 @@ class FeedForwardAttention(tf.keras.layers.Layer):
 class HierarchicalAttention(tf.keras.layers.Layer):
     """https://www.aclweb.org/anthology/N16-1174/"""
     def __init__(self):
-        super(AttentionMatrix, self).__init__()
+        super(HierarchicalAttention, self).__init__()
     
     def build(self, input_shape):
         self.attention_matrix = self.add_weight(shape=(input_shape[-1], input_shape[-2]), trainable=True, initializer='uniform')

--- a/wellcomeml/ml/attention.py
+++ b/wellcomeml/ml/attention.py
@@ -1,0 +1,33 @@
+class SelfAttention(tf.keras.layers.Layer):
+    def __init__(self, attention_dim=20):
+        super(SelfAttention, self).__init__()
+        self.attention_dim = attention_dim
+
+    def build(self, input_shape):
+        self.WQ = self.add_weight(shape=(input_shape[-1], self.attention_dim), trainable=True, initializer='uniform')
+        self.WK = self.add_weight(shape=(input_shape[-1], self.attention_dim), trainable=True, initializer='uniform')
+        self.WV = self.add_weight(shape=(input_shape[-1], input_shape[-1]), trainable=True, initializer='uniform')
+
+    def call(self, X):
+    	"""
+    	X: (batch_size, sequence_length, embedding_dimension)
+    	"""
+        Q = tf.matmul(X, self.WQ)
+        K = tf.matmul(X, self.WK)
+        V = tf.matmul(X, self.WV)
+        
+        attention_scores = tf.nn.softmax(tf.matmul(Q, tf.transpose(K, perm=[0,2,1])))
+        return tf.matmul(attention_scores, V)
+
+class AttentionMatrix(tf.keras.layers.Layer):
+    def __init__(self):
+        super(AttentionMatrix, self).__init__()
+    
+    def build(self, input_shape):
+        self.attention_matrix = self.add_weight(shape=(input_shape[-2], input_shape[-2]), trainable=True, initializer='uniform')
+    
+    def call(self, X):
+    	"""
+    	X: (batch_size, sequence_length, embedding_dimension)
+    	"""
+        return tf.matmul(self.attention_matrix, X)


### PR DESCRIPTION
Adds three different implementations for attentions that can be used for text classification

- Self attention is the one used in BERT
- Hierarchical attention is the one used in Spacy
- Feed forward attention is a simplest form of the above and quite a common depiction of attention

I am adding hierarchical attention to the models with a param that defaults to False so someone can easily enable and experiment whether it improves results. The reason it does not default to True is that I am getting some mixed results in the HOC dataset, possibly due to different hyper parameters that are needed. Will keep exploring this