### PR TITLE
Add pretrained param to doc2vec

### DIFF
--- a/wellcomeml/ml/doc2vec_vectorizer.py
+++ b/wellcomeml/ml/doc2vec_vectorizer.py
@@ -28,7 +28,7 @@ class Doc2VecVectorizer(BaseEstimator, TransformerMixin):
             model: underlying model architecture, one of dm or dbow. default: dm
             epochs: number of passes over training data. default: 20
             n_jobs: number of cores to use (-1 for all). default: 1
-            pretrained: pretrained doc2vec model
+            pretrained: path to directory containing saved pretrained doc2vec artifacts
         """
         self.vector_size = vector_size
         self.window_size = window_size

--- a/wellcomeml/ml/doc2vec_vectorizer.py
+++ b/wellcomeml/ml/doc2vec_vectorizer.py
@@ -1,5 +1,6 @@
 """Doc2Vec sklearn wrapper"""
 from collections import Counter
+from pathlib import Path
 import multiprocessing
 import statistics
 import logging
@@ -113,6 +114,7 @@ class Doc2VecVectorizer(BaseEstimator, TransformerMixin):
         return "{}/doc2vec".format(model_dir)
 
     def save(self, model_dir):
+        Path(model_dir).mkdir(parents=True, exist_ok=True)
         model_path = self._get_model_path(model_dir)
         self.model.save(model_path)
 

--- a/wellcomeml/ml/doc2vec_vectorizer.py
+++ b/wellcomeml/ml/doc2vec_vectorizer.py
@@ -109,7 +109,7 @@ class Doc2VecVectorizer(BaseEstimator, TransformerMixin):
         
         return statistics.mean(correct)
 
-    def _get_model_path(model_dir):
+    def _get_model_path(self, model_dir):
         return "{}/doc2vec".format(model_dir)
 
     def save(self, model_dir):

--- a/wellcomeml/ml/doc2vec_vectorizer.py
+++ b/wellcomeml/ml/doc2vec_vectorizer.py
@@ -15,7 +15,7 @@ logging.getLogger("gensim").setLevel(logging.WARNING)
 class Doc2VecVectorizer(BaseEstimator, TransformerMixin):
     def __init__(self, vector_size=100, window_size=5, n_jobs=1,
                  min_count=2, negative=5, sample=1e-5, epochs=20,
-                 learning_rate=0.025, model="dm"):
+                 learning_rate=0.025, model="dm", pretrained=None):
         """
         Args:
             vector_size: size of vector to represent text
@@ -27,6 +27,7 @@ class Doc2VecVectorizer(BaseEstimator, TransformerMixin):
             model: underlying model architecture, one of dm or dbow. default: dm
             epochs: number of passes over training data. default: 20
             n_jobs: number of cores to use (-1 for all). default: 1
+            pretrained: pretrained doc2vec model
         """
         self.vector_size = vector_size
         self.window_size = window_size
@@ -37,6 +38,7 @@ class Doc2VecVectorizer(BaseEstimator, TransformerMixin):
         self.n_jobs = n_jobs
         self.learning_rate = learning_rate
         self.model = model
+        self.pretrained = pretrained
 
     def _tokenize(self, x):
         return x.lower().split()
@@ -50,6 +52,13 @@ class Doc2VecVectorizer(BaseEstimator, TransformerMixin):
         Args:
             X: list of texts (strings)
         """
+        # If pretrained, just load, no need to fit
+        if self.pretrained:
+            # possibly better to leverage the save and load
+            with open(pretrained, "rb") as f:
+                self = pickle.loads(f.read())
+            return self
+
         if self.n_jobs == -1:
             workers = multiprocessing.cpu_count()
         else:

--- a/wellcomeml/ml/doc2vec_vectorizer.py
+++ b/wellcomeml/ml/doc2vec_vectorizer.py
@@ -54,9 +54,7 @@ class Doc2VecVectorizer(BaseEstimator, TransformerMixin):
         """
         # If pretrained, just load, no need to fit
         if self.pretrained:
-            # possibly better to leverage the save and load
-            with open(pretrained, "rb") as f:
-                self = pickle.loads(f.read())
+            self.load(self.pretrained)
             return self
 
         if self.n_jobs == -1:

--- a/wellcomeml/ml/doc2vec_vectorizer.py
+++ b/wellcomeml/ml/doc2vec_vectorizer.py
@@ -109,8 +109,13 @@ class Doc2VecVectorizer(BaseEstimator, TransformerMixin):
         
         return statistics.mean(correct)
 
-    def save(self, model_path):
+    def _get_model_path(model_dir):
+        return "{}/doc2vec".format(model_dir)
+
+    def save(self, model_dir):
+        model_path = self._get_model_path(model_dir)
         self.model.save(model_path)
 
-    def load(self, model_path):
+    def load(self, model_dir):
+        model_path = self._get_model_path(model_dir)
         self.model = Doc2Vec.load(model_path)


### PR DESCRIPTION
Adds a pretrained parameter in doc2vec that allows to load a pretrained model from a path so that the model can pretrained on a different dataset than the one that is applied which is quite common lately in NLP