### PR TITLE
Download en_core_web_sm if not available

### DIFF
--- a/wellcomeml/ml/frequency_vectorizer.py
+++ b/wellcomeml/ml/frequency_vectorizer.py
@@ -17,6 +17,9 @@ try:
 except IOError:
     from wellcomeml.__main__ import download
     download("models")
+    # pkg_resources need to be reloaded to pick up the newly installed models
+    import pkg_resources, imp
+    imp.reload(pkg_resources)
     nlp = spacy.load('en_core_web_sm', disable=['ner', 'tagger', 'parser',
                                             'textcat'])
 

--- a/wellcomeml/ml/frequency_vectorizer.py
+++ b/wellcomeml/ml/frequency_vectorizer.py
@@ -11,7 +11,13 @@ import spacy
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 from wellcomeml.logger import logger
-nlp = spacy.load('en_core_web_sm', disable=['ner', 'tagger', 'parser',
+try:
+    nlp = spacy.load('en_core_web_sm', disable=['ner', 'tagger', 'parser',
+                                                'textcat'])
+except IOError:
+    from wellcomeml.__main__ import download
+    download("models")
+    nlp = spacy.load('en_core_web_sm', disable=['ner', 'tagger', 'parser',
                                             'textcat'])
 
 


### PR DESCRIPTION
This is the same approach I have followed with sent2vec vectorizer but for a different reason. This implements the ability to download en_core_web_sm when needed. At the moment `python -c "import wellcomeml.ml"` fails upon installation because this is missing which in a way makes sense but in another is a bad user experience.