### PR TITLE
Feature/keras metrics

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,9 @@ coverage:
   precision: 2
   round: down
   status:
+    project:
+      target: auto
+      threshold: 10%
     patch:
       default:
         enabled: no

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,8 +3,9 @@ coverage:
   round: down
   status:
     project:
-      target: auto
-      threshold: 10%
+      default:
+        target: auto
+        threshold: 10%
     patch:
       default:
         enabled: no

--- a/requirements_transformers.txt
+++ b/requirements_transformers.txt
@@ -1,1 +1,2 @@
 transformers==2.6.0
+tensorflow==2.1.0

--- a/requirements_transformers.txt
+++ b/requirements_transformers.txt
@@ -1,2 +1,1 @@
 transformers==2.6.0
-tensorflow==2.1.0

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -16,7 +16,7 @@ from sklearn.metrics import f1_score, precision_score, recall_score
 import tensorflow as tf
 
 from wellcomeml.ml.attention import HierarchicalAttention
-from wellcomeml.ml.keras_utils import Metrics
+from wellcomeml.ml.keras_utils import Metrics, CategoricalMetrics
 
 class CNNClassifier(BaseEstimator, ClassifierMixin):
     def __init__(self, context_window = 3, learning_rate=0.001,
@@ -33,7 +33,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         self.multilabel = multilabel
         self.attention = attention
 
-    def fit(self, X, Y, embedding_matrix=None):
+    def fit(self, X, Y, metrics=[], embedding_matrix=None):
         sequence_length = X.shape[1]
         vocab_size = X.max() + 1
         emb_dim = embedding_matrix.shape[1] if embedding_matrix else self.hidden_size

--- a/wellcomeml/ml/keras_utils.py
+++ b/wellcomeml/ml/keras_utils.py
@@ -21,7 +21,7 @@ class Metrics(tf.keras.callbacks.Callback):
 class CategoricalMetrics(tf.keras.metrics.Metric):
     def __init__(self, metric='precision', from_logits=True,
                  threshold=0.5,
-                 binary='true', pos_label=1, **kwargs):
+                 binary='true', pos=1, **kwargs):
         """
         Categorical metrics
 
@@ -31,7 +31,7 @@ class CategoricalMetrics(tf.keras.metrics.Metric):
                         a softmax activation on input
             threshold: a threshold to calculate predictions
             binary: whether input is binary or not (in which case does average)
-            pos_label: the positive label
+            pos: the positive label (between [0, n_classes])
         """
         self.metric = metric
         name = f"categorical_{metric}"
@@ -39,15 +39,15 @@ class CategoricalMetrics(tf.keras.metrics.Metric):
         self.threshold = threshold
         self.from_logits = from_logits
         self.binary = binary
-        self.pos_label = pos_label
+        self.pos = pos
         self.value = self.add_weight(name='tp', initializer='zeros')
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         if self.from_logits:
             y_pred = tf.keras.activations.softmax(y_pred)
 
-        greater_than_threshold = tf.cast(y_pred[:, 1:] > self.threshold, 'bool')
-        positive = tf.cast(y_true, 'int32') == self.pos_label
+        greater_than_threshold = tf.cast(y_pred[:, self.pos:] > self.threshold, 'bool')
+        positive = tf.cast(y_true, 'int32') == self.pos
 
         # Epsilon added to denominators to avoid division by zero
         eps = tf.keras.backend.epsilon()

--- a/wellcomeml/ml/keras_utils.py
+++ b/wellcomeml/ml/keras_utils.py
@@ -1,6 +1,7 @@
 from sklearn.metrics import f1_score, precision_score, recall_score
 import tensorflow as tf
 
+
 class Metrics(tf.keras.callbacks.Callback):
     def __init__(self, validation_data):
         self.validation_data = validation_data
@@ -15,3 +16,79 @@ class Metrics(tf.keras.callbacks.Callback):
         r = round(recall_score(Y_val, Y_pred, average='micro'), 4)
         print(f" - val metrics: P {p:.4f} R {r:.4f} F {f1:.4f}")
         return
+
+
+class CategoricalMetrics(tf.keras.metrics.Metric):
+    def __init__(self, metric='precision', from_logits=True,
+                 threshold=0.5,
+                 binary='true', pos_label=1, **kwargs):
+        """
+        Categorical metrics
+
+        Args:
+            metric: 'precision', 'recall' or 'f1'
+            from_logits: Similar to keras 'from_logits'. If True, calculates
+                        a softmax activation on input
+            threshold: a threshold to calculate predictions
+            binary: whether input is binary or not (in which case does average)
+            pos_label: the positive label
+        """
+        self.metric = metric
+        name = f"categorical_{metric}"
+        super(CategoricalMetrics, self).__init__(name=name, **kwargs)
+        self.threshold = threshold
+        self.from_logits = from_logits
+        self.binary = binary
+        self.pos_label = pos_label
+        self.value = self.add_weight(name='tp', initializer='zeros')
+
+    def update_state(self, y_true, y_pred, sample_weight=None):
+        if self.from_logits:
+            y_pred = tf.keras.activations.softmax(y_pred)
+
+        greater_than_threshold = tf.cast(y_pred[:, 1:] > self.threshold, 'bool')
+        positive = tf.cast(y_true, 'int32') == self.pos_label
+
+        # Epsilon added to denominators to avoid division by zero
+        eps = tf.keras.backend.epsilon()
+
+        tp = tf.reduce_sum(
+            tf.cast(
+                tf.logical_and(greater_than_threshold, positive),
+                'float32'
+            )
+        )
+
+        if self.metric in ['precision', 'f1_score']:
+            tp_plus_fp = tf.reduce_sum(
+                tf.cast(
+                    greater_than_threshold,
+                    'float32'
+                )
+            )
+            precision = tp/(tp_plus_fp+eps)
+
+        if self.metric in ['recall', 'f1_score']:
+            tp_plus_fn = tf.reduce_sum(
+                tf.cast(
+                    positive,
+                    'float32'
+                )
+            )
+            recall = tp/(tp_plus_fn+eps)
+
+        if self.metric == 'precision':
+            self.value.assign(precision)
+        elif self.metric == 'recall':
+            self.value.assign(recall)
+        elif self.metric == 'f1_score':
+            self.value.assign(
+                2*precision*recall/(precision+recall+eps)
+            )
+
+    def result(self):
+        return self.value
+
+    def reset_states(self):
+        # The state of the metric will be reset at the start of each epoch.
+        self.value.assign(0.)


### PR DESCRIPTION
Adds Keras metrics (precision, recall, f1) and saves the metrics per-mini-batch in the model history to allow us to plot a fine evolution of training metrics.

This partially addresses https://github.com/wellcometrust/WellcomeML/issues/42. Both additions also works for the `cnn_classifier` and `bilstm_classifier` in the binary case, but I didn't want to make breaking changes so didn't turn it on by default.

Perhaps when we address https://github.com/wellcometrust/WellcomeML/issues/45, we can add the non-binary case to the metrics.