### PR TITLE
Moving model downloads inside classes

### DIFF
--- a/wellcomeml/__main__.py
+++ b/wellcomeml/__main__.py
@@ -12,7 +12,7 @@ def download(download_target):
             'python', '-m', 'spacy', 'download', 'en_trf_bertbaseuncased_lg'])
     elif download_target == "non_pypi_packages":
         subprocess.run([
-            'pip', 'install', 'git+https://github.com/epfml/sent2vec.git'])
+            'build/virtualenv/bin/pip', 'install', 'git+https://github.com/epfml/sent2vec.git'])
     else:
         print(f"{download_target} is not one of models,deeplearning-models")
 

--- a/wellcomeml/__main__.py
+++ b/wellcomeml/__main__.py
@@ -12,7 +12,7 @@ def download(download_target):
             'python', '-m', 'spacy', 'download', 'en_trf_bertbaseuncased_lg'])
     elif download_target == "non_pypi_packages":
         subprocess.run([
-            'build/virtualenv/bin/pip', 'install', 'git+https://github.com/epfml/sent2vec.git'])
+            'pip', 'install', 'git+https://github.com/epfml/sent2vec.git'])
     else:
         print(f"{download_target} is not one of models,deeplearning-models")
 

--- a/wellcomeml/ml/frequency_vectorizer.py
+++ b/wellcomeml/ml/frequency_vectorizer.py
@@ -11,17 +11,6 @@ import spacy
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 from wellcomeml.logger import logger
-try:
-    nlp = spacy.load('en_core_web_sm', disable=['ner', 'tagger', 'parser',
-                                                'textcat'])
-except IOError:
-    from wellcomeml.__main__ import download
-    download("models")
-    # pkg_resources need to be reloaded to pick up the newly installed models
-    import pkg_resources, imp
-    imp.reload(pkg_resources)
-    nlp = spacy.load('en_core_web_sm', disable=['ner', 'tagger', 'parser',
-                                            'textcat'])
 
 
 class WellcomeTfidf(TfidfVectorizer):
@@ -92,6 +81,19 @@ class WellcomeTfidf(TfidfVectorizer):
         Returns:
 
         """
+
+        try:
+            nlp = spacy.load('en_core_web_sm', disable=['ner', 'tagger', 'parser',
+                                                        'textcat'])
+        except IOError:
+            from wellcomeml.__main__ import download
+            download("models")
+            # pkg_resources need to be reloaded to pick up the newly installed models
+            import pkg_resources, imp
+            imp.reload(pkg_resources)
+            nlp = spacy.load('en_core_web_sm', disable=['ner', 'tagger', 'parser',
+                                                    'textcat'])
+
         logger.info("Using spacy pre-trained lemmatiser.")
         if remove_stopwords_and_punct:
             return [

--- a/wellcomeml/ml/sent2vec_vectorizer.py
+++ b/wellcomeml/ml/sent2vec_vectorizer.py
@@ -8,7 +8,11 @@ from wellcomeml.utils import check_cache_and_download
 
 
 class Sent2VecVectorizer(BaseEstimator, TransformerMixin):
+
     def __init__(self, pretrained=None):
+        self.pretrained=pretrained
+
+    def fit(self, *_):
 
         try:
             import sent2vec
@@ -16,10 +20,7 @@ class Sent2VecVectorizer(BaseEstimator, TransformerMixin):
             from wellcomeml.__main__ import download
             download("non_pypi_packages")
             import sent2vec
-    
-        self.pretrained=pretrained
 
-    def fit(self, *_):
         if self.pretrained:
             model_path = check_cache_and_download(self.pretrained)
             self.model = sent2vec.Sent2vecModel()

--- a/wellcomeml/ml/sent2vec_vectorizer.py
+++ b/wellcomeml/ml/sent2vec_vectorizer.py
@@ -3,18 +3,20 @@ Vectorizer that exposes sklearn interface to sent2vec
 paper and codebase. https://github.com/epfml/sent2vec
 """
 from sklearn.base import TransformerMixin, BaseEstimator
-try:
-    import sent2vec
-except ImportError:
-    from wellcomeml.__main__ import download
-    download("non_pypi_packages")
-    import sent2vec
 
 from wellcomeml.utils import check_cache_and_download
 
 
 class Sent2VecVectorizer(BaseEstimator, TransformerMixin):
     def __init__(self, pretrained=None):
+
+        try:
+            import sent2vec
+        except ImportError:
+            from wellcomeml.__main__ import download
+            download("non_pypi_packages")
+            import sent2vec
+    
         self.pretrained=pretrained
 
     def fit(self, *_):

--- a/wellcomeml/ml/spacy_knowledge_base.py
+++ b/wellcomeml/ml/spacy_knowledge_base.py
@@ -40,7 +40,15 @@ class SpacyKnowledgeBase(object):
             }]
             probabilities are 'prior probabilities' and must sum to < 1
         """
-        nlp = spacy.load(self.kb_model)
+        try:
+            nlp = spacy.load(self.kb_model)
+        except IOError:
+            subprocess.run(['python', '-m', 'spacy', 'download', self.kb_model])
+            # pkg_resources need to be reloaded to pick up the newly installed models
+            import pkg_resources, imp
+            imp.reload(pkg_resources)
+            nlp = spacy.load(self.kb_model)
+
         print("Loaded model '%s'" % self.kb_model)
         kb = KnowledgeBase(vocab=nlp.vocab, entity_vector_length=self.desc_width)
 


### PR DESCRIPTION
Fixes https://github.com/wellcometrust/WellcomeML/issues/67

- in `frequency_vectorizer.py` I move the `nlp` download to `spacy_lemmatizer` rather than the init since spacy_lemmatizer doesnt always need to be used and it is the only place en_core_web_sm is needed

Also
- download model when needed in spacy knowledge base too (which I think would have been breaking if i hadnt done this since en_core_web_lg was never downloaded!)


I went through the other wellcome ml files to look for any other times models were downloaded, but could spot any. But let me know if you know of any and I can make sure their download is only done when necessary.

Note for putting these checks in classes: it failed for `Sent2VecVectorizer` when the download checks were in the __init__, so I put them in the `fit` function since this is where sent2vec is needed, and then it worked