### PR TITLE
Add early stopping in BiLSTM and CNN

### DIFF
--- a/tests/test_bilstm.py
+++ b/tests/test_bilstm.py
@@ -63,3 +63,25 @@ def test_attention():
     ])
     model.fit(X, Y)
     assert model.score(X, Y) > 0.6
+
+
+def test_early_stopping():
+    X = [
+        "One",
+        "One only",
+        "Two nothing else",
+        "Two and three"
+    ]
+    Y = np.array([0, 0, 1, 1])
+
+    model = Pipeline([
+        ('vec', KerasVectorizer()),
+        ('clf', BiLSTMClassifier(
+                    early_stopping=True,
+                    nb_epochs=10000
+        ))
+    ])
+    # if early_stopping is not working it will take
+    # a lot of time to finish running this test
+    model.fit(X, Y)
+    assert model.score(X, Y) > 0.6

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -61,3 +61,25 @@ def test_attention():
     ])
     model.fit(X, Y)
     assert model.score(X, Y) > 0.6
+
+
+def test_early_stopping():
+    X = [
+        "One",
+        "One only",
+        "Two nothing else",
+        "Two and three"
+    ]
+    Y = np.array([0, 0, 1, 1])
+
+    model = Pipeline([
+        ('vec', KerasVectorizer()),
+        ('clf', CNNClassifier(
+                    early_stopping=True,
+                    nb_epochs=10000
+        ))
+    ])
+    # if early_stopping is not working it will take
+    # a lot of time to finish running this test
+    model.fit(X, Y)
+    assert model.score(X, Y) > 0.6

--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -35,7 +35,7 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
         metrics=["precision", "recall"],
         callbacks=["tensorboard"],
         feature_approach="max",
-        early_stopping = False
+        early_stopping=False
     ):
         self.learning_rate = learning_rate
         self.batch_size = batch_size
@@ -136,7 +136,8 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
             for c in self.callbacks
         ]
         if self.early_stopping:
-            early_stopping = tf.keras.callbacks.EarlyStopping(patience=5, restore_best_weights=True)
+            early_stopping = tf.keras.callbacks.EarlyStopping(
+                patience=5, restore_best_weights=True)
             callbacks.append(early_stopping)
         self.model.fit(
             X_train,

--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -34,7 +34,8 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
         attention=False,
         metrics=["precision", "recall"],
         callbacks=["tensorboard"],
-        feature_approach="max"
+        feature_approach="max",
+        early_stopping = False
     ):
         self.learning_rate = learning_rate
         self.batch_size = batch_size
@@ -50,6 +51,7 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
         self.metrics = metrics
         self.callbacks = callbacks
         self.feature_approach = feature_approach
+        self.early_stopping = early_stopping
 
     def _build_model(self, sequence_length, vocab_size, nb_outputs,
                      embedding_matrix=None, metrics=["precision", "recall"]):
@@ -133,6 +135,9 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
             CALLBACK_DICT[c] if c in CALLBACK_DICT else c
             for c in self.callbacks
         ]
+        if self.early_stopping:
+            early_stopping = tf.keras.callbacks.EarlyStopping(patience=5, restore_best_weights=True)
+            callbacks.append(early_stopping)
         self.model.fit(
             X_train,
             Y_train,

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -67,6 +67,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         self.metrics = metrics
         self.callbacks = callbacks
         self.feature_approach = feature_approach
+        self.early_stopping = early_stopping
 
     def _build_model(self, sequence_length, vocab_size, nb_outputs,
                      embedding_matrix=None, metrics=["precision", "recall"]):

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -48,7 +48,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         metrics=["precision", "recall"],
         callbacks=["tensorboard"],
         feature_approach="max",
-        early_stopping = False
+        early_stopping=False
     ):
         self.context_window = context_window
         self.learning_rate = learning_rate
@@ -163,7 +163,8 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             for c in self.callbacks
         ]
         if self.early_stopping:
-            early_stopping = tf.keras.callbacks.EarlyStopping(patience=5, restore_best_weights=True)
+            early_stopping = tf.keras.callbacks.EarlyStopping(
+                patience=5, restore_best_weights=True)
             callbacks.append(early_stopping)
         self.model.fit(
             X_train,

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -47,7 +47,8 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         attention_heads='same',
         metrics=["precision", "recall"],
         callbacks=["tensorboard"],
-        feature_approach="max"
+        feature_approach="max",
+        early_stopping = False
     ):
         self.context_window = context_window
         self.learning_rate = learning_rate
@@ -160,6 +161,9 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             CALLBACK_DICT[c] if c in CALLBACK_DICT else c
             for c in self.callbacks
         ]
+        if self.early_stopping:
+            early_stopping = tf.keras.callbacks.EarlyStopping(patience=5, restore_best_weights=True)
+            callbacks.append(early_stopping)
         self.model.fit(
             X_train,
             Y_train,


### PR DESCRIPTION
Description
---
Fixes #139 

Adds param early_stopping with a default patience of 5 epochs and default ability to restore best weights. In the future these can also be params.

Checklist
---

- [x] Added link to Github issue or Trello card
- [x] Added tests
