### PR TITLE
Add sparse_y param to BiLSTM and CNN that streams sparse Y

### DIFF
--- a/tests/test_bilstm.py
+++ b/tests/test_bilstm.py
@@ -1,6 +1,7 @@
 from wellcomeml.ml.bilstm import BiLSTMClassifier
 from wellcomeml.ml import KerasVectorizer
 from sklearn.pipeline import Pipeline
+from scipy.sparse import csr_matrix
 import numpy as np
 
 
@@ -39,6 +40,34 @@ def test_multilabel():
     model = Pipeline([
         ('vec', KerasVectorizer()),
         ('clf', BiLSTMClassifier(multilabel=True))
+    ])
+    model.fit(X, Y)
+    assert model.score(X, Y) > 0.4
+    assert model.predict(X).shape == (5, 4)
+
+
+def test_sparse():
+    X = [
+        "One and two",
+        "One only",
+        "Three and four, nothing else",
+        "Two nothing else",
+        "Two and three"
+    ]
+    Y = csr_matrix(np.array([
+        [1, 1, 0, 0],
+        [1, 0, 0, 0],
+        [0, 0, 1, 1],
+        [0, 1, 0, 0],
+        [0, 1, 1, 0]
+    ]))
+    model = Pipeline([
+        ('vec', KerasVectorizer()),
+        ('clf', BiLSTMClassifier(
+            multilabel=True,
+            batch_size=2,
+            sparse_y=True
+        ))
     ])
     model.fit(X, Y)
     assert model.score(X, Y) > 0.4

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -1,5 +1,6 @@
 from wellcomeml.ml import CNNClassifier, KerasVectorizer
 from sklearn.pipeline import Pipeline
+from scipy.sparse import csr_matrix
 import numpy as np
 
 
@@ -38,6 +39,33 @@ def test_multilabel():
     model = Pipeline([
         ('vec', KerasVectorizer()),
         ('clf', CNNClassifier(multilabel=True))
+    ])
+    model.fit(X, Y)
+    assert model.score(X, Y) > 0.4
+    assert model.predict(X).shape == (5, 4)
+
+
+def test_sparse():
+    X = [
+        "One and two",
+        "One only",
+        "Three and four, nothing else",
+        "Two nothing else",
+        "Two and three"
+    ]
+    Y = csr_matrix(np.array([
+        [1, 1, 0, 0],
+        [1, 0, 0, 0],
+        [0, 0, 1, 1],
+        [0, 1, 0, 0],
+        [0, 1, 1, 0]
+    ]))
+    model = Pipeline([
+        ('vec', KerasVectorizer()),
+        ('clf', CNNClassifier(
+            multilabel=True,
+            batch_size=2,
+            sparse_y=True))
     ])
     model.fit(X, Y)
     assert model.score(X, Y) > 0.4

--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import math
 
 from sklearn.model_selection import train_test_split
 from sklearn.base import BaseEstimator, ClassifierMixin
@@ -35,7 +36,8 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
         metrics=["precision", "recall"],
         callbacks=["tensorboard"],
         feature_approach="max",
-        early_stopping=False
+        early_stopping=False,
+        sparse_y = False
     ):
         self.learning_rate = learning_rate
         self.batch_size = batch_size
@@ -52,6 +54,17 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
         self.callbacks = callbacks
         self.feature_approach = feature_approach
         self.early_stopping = early_stopping
+        self.sparse_y = sparse_y
+
+    def _yield_data(X, Y, batch_size, shuffle=True):
+        while True:
+            if shuffle:
+                randomize = np.arange(len(X))
+                np.random.shuffle(randomize)
+                X = X[randomize]
+                Y = Y[randomize]
+            for i in range(0, X.shape[0], batch_size):
+                yield X[i:i+batch_size, :], Y[i:i+batch_size, :].todense()
 
     def _build_model(self, sequence_length, vocab_size, nb_outputs,
                      embedding_matrix=None, metrics=["precision", "recall"]):
@@ -139,18 +152,41 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
             early_stopping = tf.keras.callbacks.EarlyStopping(
                 patience=5, restore_best_weights=True)
             callbacks.append(early_stopping)
-        self.model.fit(
-            X_train,
-            Y_train,
-            epochs=self.nb_epochs,
-            batch_size=self.batch_size,
-            validation_data=(X_val, Y_val),
-            callbacks=callbacks,
-        )
+        if self.sparse_y:
+            train_data = self.yield_data(X_train, Y_train, self.batch_size)
+            test_data = self.yield_data(X_test, Y_test, self.batch_size)
+            steps_per_epoch = math.ceil(X_train.shape[0] / self.batch_size)
+            validation_steps = math.ceil(X_test.shape[0] / self.batch_size)
+
+            self.model.fit(
+                x=train_data,
+                steps_per_epoch=steps_per_epoch,
+                validation_data=test_data,
+                validation_steps=validation_steps,
+                epochs=self.nb_epochs,
+                callbacks=callbacks)
+        else:
+            self.model.fit(
+                X_train,
+                Y_train,
+                epochs=self.nb_epochs,
+                batch_size=self.batch_size,
+                validation_data=(X_val, Y_val),
+                callbacks=callbacks,
+            )
         return self
 
     def predict(self, X, *_):
-        return self.model(X).numpy() > 0.5
+        if self.sparse_y:
+            Y_pred = []
+            for i in range(0, X.shape[0], self.batch_size):
+                X_batch = X[i: i+batch_size]
+                Y_pred_batch = self.model(X_batch) > 0.5
+                Y_pred.append(csr_matrix(Y_pred_batch))
+            Y_pred = vstack(Y_pred)
+            return Y_pred
+        else:
+            return self.model(X).numpy() > 0.5
 
     def score(self, X, Y):
         Y_pred = self.predict(X)

--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -4,7 +4,7 @@ import math
 from sklearn.model_selection import train_test_split
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.metrics import f1_score
-from scipy import csr_matrix, vstack
+from scipy.sparse import csr_matrix, vstack
 import tensorflow as tf
 import numpy as np
 
@@ -58,7 +58,7 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
         self.early_stopping = early_stopping
         self.sparse_y = sparse_y
 
-    def _yield_data(X, Y, batch_size, shuffle=True):
+    def _yield_data(self, X, Y, batch_size, shuffle=True):
         while True:
             if shuffle:
                 randomize = np.arange(len(X))
@@ -155,8 +155,8 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
                 patience=5, restore_best_weights=True)
             callbacks.append(early_stopping)
         if self.sparse_y:
-            train_data = self.yield_data(X_train, Y_train, self.batch_size)
-            val_data = self.yield_data(X_val, Y_val, self.batch_size)
+            train_data = self._yield_data(X_train, Y_train, self.batch_size)
+            val_data = self._yield_data(X_val, Y_val, self.batch_size)
             steps_per_epoch = math.ceil(X_train.shape[0] / self.batch_size)
             validation_steps = math.ceil(X_val.shape[0] / self.batch_size)
 

--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -66,7 +66,11 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
                 X = X[randomize]
                 Y = Y[randomize]
             for i in range(0, X.shape[0], batch_size):
-                yield X[i:i+batch_size, :], Y[i:i+batch_size, :].todense()
+                X_batch = X[i:i+batch_size, :]
+                Y_batch = Y[i:i+batch_size, :]
+                if self.sparse_y:
+                    Y_batch = Y_batch.todense()
+                yield X_batch, Y_batch
 
     def _build_model(self, sequence_length, vocab_size, nb_outputs,
                      embedding_matrix=None, metrics=["precision", "recall"]):

--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -4,7 +4,9 @@ import math
 from sklearn.model_selection import train_test_split
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.metrics import f1_score
+from scipy import csr_matrix, vstack
 import tensorflow as tf
+import numpy as np
 
 from wellcomeml.ml.attention import HierarchicalAttention
 
@@ -37,7 +39,7 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
         callbacks=["tensorboard"],
         feature_approach="max",
         early_stopping=False,
-        sparse_y = False
+        sparse_y=False
     ):
         self.learning_rate = learning_rate
         self.batch_size = batch_size
@@ -154,14 +156,14 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
             callbacks.append(early_stopping)
         if self.sparse_y:
             train_data = self.yield_data(X_train, Y_train, self.batch_size)
-            test_data = self.yield_data(X_test, Y_test, self.batch_size)
+            val_data = self.yield_data(X_val, Y_val, self.batch_size)
             steps_per_epoch = math.ceil(X_train.shape[0] / self.batch_size)
-            validation_steps = math.ceil(X_test.shape[0] / self.batch_size)
+            validation_steps = math.ceil(X_val.shape[0] / self.batch_size)
 
             self.model.fit(
                 x=train_data,
                 steps_per_epoch=steps_per_epoch,
-                validation_data=test_data,
+                validation_data=val_data,
                 validation_steps=validation_steps,
                 epochs=self.nb_epochs,
                 callbacks=callbacks)
@@ -180,7 +182,7 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
         if self.sparse_y:
             Y_pred = []
             for i in range(0, X.shape[0], self.batch_size):
-                X_batch = X[i: i+batch_size]
+                X_batch = X[i: i+self.batch_size]
                 Y_pred_batch = self.model(X_batch) > 0.5
                 Y_pred.append(csr_matrix(Y_pred_batch))
             Y_pred = vstack(Y_pred)

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -11,10 +11,12 @@ Predict: softmax or sigmoid depending on number of outputs
     and whether task is multilabel
 """
 from datetime import datetime
+import math
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import f1_score
+from scipy.sparse import csr_matrix, vstack
 import tensorflow as tf
 
 from wellcomeml.ml.attention import HierarchicalAttention
@@ -48,7 +50,8 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         metrics=["precision", "recall"],
         callbacks=["tensorboard"],
         feature_approach="max",
-        early_stopping=False
+        early_stopping=False,
+        sparse_y = False
     ):
         self.context_window = context_window
         self.learning_rate = learning_rate
@@ -68,6 +71,17 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         self.callbacks = callbacks
         self.feature_approach = feature_approach
         self.early_stopping = early_stopping
+        self.sparse_y = sparse_y
+
+    def _yield_data(X, Y, batch_size, shuffle=True):
+        while True:
+            if shuffle:
+                randomize = np.arange(len(X))
+                np.random.shuffle(randomize)
+                X = X[randomize]
+                Y = Y[randomize]
+            for i in range(0, X.shape[0], batch_size):
+                yield X[i:i+batch_size, :], Y[i:i+batch_size, :].todense()
 
     def _build_model(self, sequence_length, vocab_size, nb_outputs,
                      embedding_matrix=None, metrics=["precision", "recall"]):
@@ -166,18 +180,41 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             early_stopping = tf.keras.callbacks.EarlyStopping(
                 patience=5, restore_best_weights=True)
             callbacks.append(early_stopping)
-        self.model.fit(
-            X_train,
-            Y_train,
-            epochs=self.nb_epochs,
-            batch_size=self.batch_size,
-            validation_data=(X_val, Y_val),
-            callbacks=callbacks,
-        )
+        if self.sparse_y:
+            train_data = self.yield_data(X_train, Y_train, self.batch_size)
+            test_data = self.yield_data(X_test, Y_test, self.batch_size)
+            steps_per_epoch = math.ceil(X_train.shape[0] / self.batch_size)
+            validation_steps = math.ceil(X_test.shape[0] / self.batch_size)
+
+            self.model.fit(
+                x=train_data,
+                steps_per_epoch=steps_per_epoch,
+                validation_data=test_data,
+                validation_steps=validation_steps,
+                epochs=self.nb_epochs,
+                callbacks=callbacks)
+        else:
+            self.model.fit(
+                X_train,
+                Y_train,
+                epochs=self.nb_epochs,
+                batch_size=self.batch_size,
+                validation_data=(X_val, Y_val),
+                callbacks=callbacks,
+            )
         return self
 
     def predict(self, X):
-        return self.model(X).numpy() > 0.5
+        if self.sparse_y:
+            Y_pred = []
+            for i in range(0, X.shape[0], self.batch_size):
+                X_batch = X[i: i+batch_size]
+                Y_pred_batch = self.model(X_batch) > 0.5
+                Y_pred.append(csr_matrix(Y_pred_batch))
+            Y_pred = vstack(Y_pred)
+            return Y_pred
+        else:
+            return self.model(X).numpy() > 0.5
 
     def score(self, X, Y):
         Y_pred = self.predict(X)

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -82,7 +82,11 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
                 X = X[randomize]
                 Y = Y[randomize]
             for i in range(0, X.shape[0], batch_size):
-                yield X[i:i+batch_size, :], Y[i:i+batch_size, :].todense()
+                X_batch = X[i:i+batch_size, :]
+                Y_batch = Y[i:i+batch_size, :]
+                if self.sparse_y:
+                    Y_batch = Y_batch.todense()
+                yield X_batch, Y_batch
 
     def _build_model(self, sequence_length, vocab_size, nb_outputs,
                      embedding_matrix=None, metrics=["precision", "recall"]):

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -74,7 +74,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         self.early_stopping = early_stopping
         self.sparse_y = sparse_y
 
-    def _yield_data(X, Y, batch_size, shuffle=True):
+    def _yield_data(self, X, Y, batch_size, shuffle=True):
         while True:
             if shuffle:
                 randomize = np.arange(len(X))
@@ -182,8 +182,8 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
                 patience=5, restore_best_weights=True)
             callbacks.append(early_stopping)
         if self.sparse_y:
-            train_data = self.yield_data(X_train, Y_train, self.batch_size)
-            val_data = self.yield_data(X_val, Y_val, self.batch_size)
+            train_data = self._yield_data(X_train, Y_train, self.batch_size)
+            val_data = self._yield_data(X_val, Y_val, self.batch_size)
             steps_per_epoch = math.ceil(X_train.shape[0] / self.batch_size)
             validation_steps = math.ceil(X_val.shape[0] / self.batch_size)
 


### PR DESCRIPTION
Description
---
Fixes #138 

Solves the problem of tensorflow not working with sparse Y vectors like the ones we have for MeSH by introducing a param sparse_y which forces the data to be streamed and converts to dense as per needed which is more memory friendly than densifying the entire Y.

Checklist
---

- [x] Added link to Github issue or Trello card
- [x] Added tests
