### PR TITLE
Fix __all__ to return strings instead of modules

### DIFF
--- a/wellcomeml/__init__.py
+++ b/wellcomeml/__init__.py
@@ -5,6 +5,6 @@ from .__version__ import (
 from .logger import logger
 
 __all__ = [
-    __name__, __version__, __description__, __url__,
-    __author__, __author_email__, __license__, logger
+    '__name__', '__version__', '__description__', '__url__',
+    '__author__', '__author_email__', '__license__', 'logger'
 ]

--- a/wellcomeml/datasets/__init__.py
+++ b/wellcomeml/datasets/__init__.py
@@ -1,3 +1,3 @@
 from wellcomeml.datasets.hoc import load_hoc
 
-__all__ = [load_hoc]
+__all__ = ['load_hoc']

--- a/wellcomeml/io/__init__.py
+++ b/wellcomeml/io/__init__.py
@@ -1,4 +1,4 @@
 from .io import read_jsonl, write_jsonl
 from .s3_policy_data import PolicyDocumentsDownloader
 
-__all__ = [read_jsonl, write_jsonl, PolicyDocumentsDownloader]
+__all__ = ['read_jsonl', 'write_jsonl', 'PolicyDocumentsDownloader']

--- a/wellcomeml/metrics/__init__.py
+++ b/wellcomeml/metrics/__init__.py
@@ -1,3 +1,3 @@
 from .ner_classification_report import ner_classification_report
 
-__all__ = [ner_classification_report]
+__all__ = ['ner_classification_report']

--- a/wellcomeml/ml/__init__.py
+++ b/wellcomeml/ml/__init__.py
@@ -15,14 +15,14 @@ if development_transformers_mode:
     )
 
     from .bert_semantic_equivalence import SemanticEquivalenceClassifier
-    __all__ = [SemanticEquivalenceClassifier]
+    __all__ = ['SemanticEquivalenceClassifier']
 else:
     from .frequency_vectorizer import WellcomeTfidf
     from .doc2vec_vectorizer import Doc2VecVectorizer
     from .sent2vec_vectorizer import Sent2VecVectorizer
     from .voting_classifier import WellcomeVotingClassifier
-    __all__ = [WellcomeTfidf, Doc2VecVectorizer,
-               Sent2VecVectorizer, WellcomeVotingClassifier]
+    __all__ = ['WellcomeTfidf', 'Doc2VecVectorizer',
+               'Sent2VecVectorizer', 'WellcomeVotingClassifier']
 
     try:
         from .vectorizer import Vectorizer
@@ -39,10 +39,11 @@ else:
         from .bilstm import BiLSTMClassifier
         from .keras_vectorizer import KerasVectorizer
         __all__ += [
-            Vectorizer, TextClustering, SpacyNER, SpacyClassifier,
-            BertClassifier, BertVectorizer, SpacyKnowledgeBase,
-            SpacyEntityLinker, SemanticEquivalenceClassifier, CNNClassifier,
-            BiLSTMClassifier, KerasVectorizer, SimilarityEntityLinker
+            'Vectorizer', 'TextClustering', 'SpacyNER', 'SpacyClassifier',
+            'BertClassifier', 'BertVectorizer', 'SpacyKnowledgeBase',
+            'SpacyEntityLinker', 'SemanticEquivalenceClassifier',
+            'CNNClassifier', 'BiLSTMClassifier', 'KerasVectorizer',
+            'SimilarityEntityLinker'
         ]
     except ImportError:
         logger.warning("Using WellcomeML without extras (transformers & torch).")

--- a/wellcomeml/spacy/__init__.py
+++ b/wellcomeml/spacy/__init__.py
@@ -1,3 +1,3 @@
 from .spacy_doc_to_prodigy import SpacyDocToProdigy
 
-__all__ = [SpacyDocToProdigy]
+__all__ = ['SpacyDocToProdigy']


### PR DESCRIPTION
Description
---

Fixes https://github.com/wellcometrust/WellcomeML/issues/146

If we add modules (instead of string) to `__all__` some times it breaks imports (*) as in:

```bash
TypeError                                 Traceback (most recent call last)
<ipython-input-1-c7541d84f48f> in <module>
----> 1 from wellcomeml.ml import *

~/WellcomeML/build/virtualenv/lib/python3.7/importlib/_bootstrap.py in _handle_fromlist(module, fromlist, import_, recursive)

~/WellcomeML/build/virtualenv/lib/python3.7/importlib/_bootstrap.py in _handle_fromlist(module, fromlist, import_, recursive)

TypeError: Item in wellcomeml.ml.__all__ must be str, not type
```
---

- [x] Added link to Github issue or Trello card
- [ ] ~~Added tests~~ (not necessary)
