### PR TITLE
Fix docstrings formatting

### DIFF
--- a/wellcomeml/datasets/winer.py
+++ b/wellcomeml/datasets/winer.py
@@ -74,14 +74,15 @@ def create_train_test(
     them from the vectorised form in the docs_path file
     using the vocab_path file.
 
-    NE_path: File path to the WiNER raw data named entities
-    vocab_path: File path to the WiNER raw data vocab dictionary
-    docs_path: File path to the WiNER raw data documents texts
+    Args:
+        NE_path: File path to the WiNER raw data named entities
+        vocab_path: File path to the WiNER raw data vocab dictionary
+        docs_path: File path to the WiNER raw data documents texts
             (words coded according to the vocab)
-    train_processed_path: Output file path for the training data
-    test_processed_path: Output file path for the testing data
-    n_sample: Number of files to get data from, each file contains about 1000 documents
-    prop_train: Proportion of the file sample that will be in the training data
+        train_processed_path: Output file path for the training data
+        test_processed_path: Output file path for the testing data
+        n_sample: Number of files to get data from, each file contains about 1000 documents
+        prop_train: Proportion of the file sample that will be in the training data
 
     Utilise the three datasources to get the entities from a sample
     of documents and save to a training and testing dataset files

--- a/wellcomeml/io/s3_policy_data.py
+++ b/wellcomeml/io/s3_policy_data.py
@@ -7,7 +7,8 @@ import os
 class PolicyDocumentsDownloader:
     """
     Interact with S3 to get policy document texts
-    Input:
+
+    Args:
         bucket_name: the S3 bucket name to get data from
         dir_path: the directory path within this s3 bucket to get policy data from
     """
@@ -43,10 +44,12 @@ class PolicyDocumentsDownloader:
     def get_hashes(self, word_list=None):
         """
         Get a list of policy document hashes from the S3 location
-        Input:
-            word_list: a list of words to look for in documents, if None then get hashes for all
-        Output:
-            hashes: a list of dicts with the file hash and the policy doc source where it is from
+
+        Args:
+            word_list(list): a list of words to look for in documents, if None then get hashes for
+                all
+        Returns:
+            list: a list of dicts with the file hash and the policy doc source where it is from
         """
 
         print("Getting hashes for policy documents")
@@ -75,7 +78,8 @@ class PolicyDocumentsDownloader:
     def download(self, hash_list=None):
         """
         Download the policy document data from S3
-        Input:
+
+        Args:
             hash_list: a list of hashes to specifically download, if None then download all
         """
 

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -2,12 +2,16 @@
 CNN architecture inspired from spacy for NLP tasks
 
 It follows the embed, encode, attend, predict framework
-Embed: learns a new embedding but can receive
+
+    Embed: learns a new embedding but can receive
     pre trained embeddings as well
-Encode: stacked CNN with context window 3 that maintains
-    the size of input and applies dropout and layer norm
-Attend: not yet implemented
-Predict: softmax or sigmoid depending on number of outputs
+
+    Encode: stacked CNN with context window 3 that maintains the size of input and applies dropout
+    and layer norm
+
+    Attend: not yet implemented
+
+    Predict: softmax or sigmoid depending on number of outputs
     and whether task is multilabel
 """
 from datetime import datetime

--- a/wellcomeml/ml/keras_utils.py
+++ b/wellcomeml/ml/keras_utils.py
@@ -36,7 +36,7 @@ class CategoricalMetrics(tf.keras.metrics.Metric):
         Args:
             metric: 'precision', 'recall' or 'f1'
             from_logits: Similar to keras 'from_logits'. If True, calculates
-                        a softmax activation on input
+                a softmax activation on input
             threshold: a threshold to calculate predictions
             binary: whether input is binary or not (in which case does average)
             pos: the positive label (between [0, n_classes])

--- a/wellcomeml/ml/spacy_entity_linking.py
+++ b/wellcomeml/ml/spacy_entity_linking.py
@@ -38,10 +38,11 @@ class SpacyEntityLinker(object):
 
     def train(self, data):
         """
-        Input:
-            data: list of training data in the form
-                [('A sentence about Farrar',
-                {'links': {(17, 22): {'Q1': 1.0, 'Q2': 0.0}}})]
+        Args:
+            data: list of training data in the form::
+
+                    [('A sentence about Farrar',
+                    {'links': {(17, 22): {'Q1': 1.0, 'Q2': 0.0}}})]
 
         See https://spacy.io/usage/linguistic-features#entity-linking
         for where I got this code from
@@ -96,12 +97,15 @@ class SpacyEntityLinker(object):
     def predict(self, data):
         """
         See how well the model predicts which entity you are referring to in your data
-        Input:
-            data: list of test data in the form
-                [('A sentence about Farrar',
-                {'links': {(17, 22): {'Q1': 1.0, 'Q2': 0.0}}})]
-        Output:
-           pred_entities_ids: ['Q1', 'Q1', 'Q2']
+
+        Args:
+            data: list of test data in the form::
+
+                    [('A sentence about Farrar',
+                    {'links': {(17, 22): {'Q1': 1.0, 'Q2': 0.0}}})]
+
+        Returns:
+            list: pred_entities_ids: ['Q1', 'Q1', 'Q2']
     """
         # TODO: Replace nlp_el with self.nlp
         nlp_el = self.nlp

--- a/wellcomeml/ml/spacy_knowledge_base.py
+++ b/wellcomeml/ml/spacy_knowledge_base.py
@@ -34,14 +34,17 @@ class SpacyKnowledgeBase(object):
 
     def train(self, entities, list_aliases):
         """
-        entities: a dict of each entity, it's description and it's corpus frequency
-        list_aliases: a list of dicts for each entity e.g.
-            [{
-                'alias':'Farrar',
-                'entities': ['Q1', 'Q2'],
-                'probabilities': [0.4, 0.6]
-            }]
-            probabilities are 'prior probabilities' and must sum to < 1
+        Args:
+            entities: a dict of each entity, it's description and it's corpus frequency
+            list_aliases: a list of dicts for each entity e.g.::
+
+                    [{
+                        'alias':'Farrar',
+                        'entities': ['Q1', 'Q2'],
+                        'probabilities': [0.4, 0.6]
+                    }]
+
+                probabilities are 'prior probabilities' and must sum to < 1
         """
         try:
             nlp = spacy.load(self.kb_model)


### PR DESCRIPTION
Description
---
Addresses #80 

In general there was indentation issues in the docstring, I edited the `Input:` to follow sphinx guidelines `Args:` (to be rendered in the build correctly). Also fixed some other issues related to the block rendering, it needed to be indented and have `::` before it to be shown in the build exactly as the written docstring.

Fixed all the errors mentioned in the ticket except for two errors (I can't see the docstring? I can't find any docstrings in the line mentioned):
- WellcomeML/wellcomeml/ml/keras_utils.py:docstring of wellcomeml.ml.keras_utils.CategoricalMetrics.update_state:5: WARNING: Unexpected indentation.
- WellcomeML/wellcomeml/ml/keras_utils.py:docstring of wellcomeml.ml.keras_utils.CategoricalMetrics.update_state:10: WARNING: Enumerated list ends without a blank line; unexpected unindent.

P.S.: I didn't know if I should have added the build changes to the PR diff, I think it would be better to be in a separate PR after this from one of the maintainers.

Checklist
---

- [x] Added link to Github issue or Trello card
