### PR TITLE
Keras vectorizer build_embedding_matrix additions

### DIFF
--- a/tests/test_keras_vectorizer.py
+++ b/tests/test_keras_vectorizer.py
@@ -34,6 +34,7 @@ def test_vocab_size():
 
     assert X_vec.max() == vocab_size
 
+
 def test_build_embedding_matrix():
 
     X = ["One", "Two", "Three"]
@@ -44,16 +45,22 @@ def test_build_embedding_matrix():
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         embeddings_path = os.path.join(tmp_dir, "embeddings.csv")
-        embeddings = ['one 0 1 0 0 0', 'two 0 0 1 0 0', 'three 0 0 0 1 0', 'four 0 0 0 0 1']
+        embeddings = [
+            "one 0 1 0 0 0",
+            "two 0 0 1 0 0",
+            "three 0 0 0 1 0",
+            "four 0 0 0 0 1",
+        ]
         with open(embeddings_path, "w") as embeddings_path_tmp:
             for line in embeddings:
                 embeddings_path_tmp.write(line)
-                embeddings_path_tmp.write('\n')
+                embeddings_path_tmp.write("\n")
         embedding_matrix = keras_vectorizer.build_embedding_matrix(
             embeddings_path=embeddings_path
-            )
+        )
 
-        assert embedding_matrix.shape==(5,5)
+        assert embedding_matrix.shape == (5, 5)
+
 
 def test_build_embedding_matrix_word_vectors():
 
@@ -64,9 +71,7 @@ def test_build_embedding_matrix_word_vectors():
     keras_vectorizer.fit(X)
 
     embedding_matrix = keras_vectorizer.build_embedding_matrix(
-        word_vectors='glove-twitter-25'
-        )
+        word_vectors="glove-twitter-25"
+    )
 
-    assert embedding_matrix.shape==(5,25)
-
-        
+    assert embedding_matrix.shape == (5, 25)

--- a/tests/test_keras_vectorizer.py
+++ b/tests/test_keras_vectorizer.py
@@ -1,3 +1,6 @@
+import tempfile
+import os
+
 from wellcomeml.ml import KerasVectorizer
 
 
@@ -30,3 +33,25 @@ def test_vocab_size():
     X_vec = keras_vectorizer.fit_transform(X)
 
     assert X_vec.max() == vocab_size
+
+def test_build_embedding_matrix():
+
+    X = ["One", "Two", "Three"]
+
+    vocab_size = 1
+    keras_vectorizer = KerasVectorizer(vocab_size=vocab_size)
+    X_vec = keras_vectorizer.fit(X)
+
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        embeddings_path = os.path.join(tmp_dir, "embeddings.csv")
+        embeddings = ['one 0 1 0 0 0', 'two 0 0 1 0 0', 'three 0 0 0 1 0', 'four 0 0 0 0 1']
+        with open(embeddings_path, "w") as embeddings_path_tmp:
+            for line in embeddings:
+                embeddings_path_tmp.write(line)
+                embeddings_path_tmp.write('\n')
+        embedding_matrix = keras_vectorizer.build_embedding_matrix(embeddings_path)
+
+        assert embedding_matrix.shape==(5,5)
+
+        

--- a/tests/test_keras_vectorizer.py
+++ b/tests/test_keras_vectorizer.py
@@ -40,8 +40,7 @@ def test_build_embedding_matrix():
 
     vocab_size = 1
     keras_vectorizer = KerasVectorizer(vocab_size=vocab_size)
-    X_vec = keras_vectorizer.fit(X)
-
+    keras_vectorizer.fit(X)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         embeddings_path = os.path.join(tmp_dir, "embeddings.csv")
@@ -50,8 +49,24 @@ def test_build_embedding_matrix():
             for line in embeddings:
                 embeddings_path_tmp.write(line)
                 embeddings_path_tmp.write('\n')
-        embedding_matrix = keras_vectorizer.build_embedding_matrix(embeddings_path)
+        embedding_matrix = keras_vectorizer.build_embedding_matrix(
+            embeddings_path=embeddings_path
+            )
 
         assert embedding_matrix.shape==(5,5)
+
+def test_build_embedding_matrix_word_vectors():
+
+    X = ["One", "Two", "Three"]
+
+    vocab_size = 1
+    keras_vectorizer = KerasVectorizer(vocab_size=vocab_size)
+    keras_vectorizer.fit(X)
+
+    embedding_matrix = keras_vectorizer.build_embedding_matrix(
+        word_vectors='glove-twitter-25'
+        )
+
+    assert embedding_matrix.shape==(5,25)
 
         

--- a/tests/test_keras_vectorizer.py
+++ b/tests/test_keras_vectorizer.py
@@ -56,7 +56,7 @@ def test_build_embedding_matrix():
                 embeddings_path_tmp.write(line)
                 embeddings_path_tmp.write("\n")
         embedding_matrix = keras_vectorizer.build_embedding_matrix(
-            embeddings_path=embeddings_path
+            embeddings_name_or_path=embeddings_path
         )
 
         assert embedding_matrix.shape == (5, 5)
@@ -71,7 +71,7 @@ def test_build_embedding_matrix_word_vectors():
     keras_vectorizer.fit(X)
 
     embedding_matrix = keras_vectorizer.build_embedding_matrix(
-        word_vectors="glove-twitter-25"
+        embeddings_name_or_path="glove-twitter-25"
     )
 
     assert embedding_matrix.shape == (5, 25)

--- a/wellcomeml/ml/keras_vectorizer.py
+++ b/wellcomeml/ml/keras_vectorizer.py
@@ -6,6 +6,9 @@ from tensorflow.keras.preprocessing.sequence import pad_sequences
 import numpy as np
 import gensim.downloader as api
 
+from os import path
+
+from wellcomeml.logger import logger
 
 class KerasVectorizer(BaseEstimator, TransformerMixin):
     def __init__(self, vocab_size=None, sequence_length=None, oov_token="<OOV>"):
@@ -22,24 +25,60 @@ class KerasVectorizer(BaseEstimator, TransformerMixin):
         sequences = self.tokenizer.texts_to_sequences(X)
         return pad_sequences(sequences, maxlen=self.sequence_length)
 
-    def build_embedding_matrix(self, embeddings_path, word_vectors='glove'):
-        if my_file.exists(embeddings_path):
-            embeddings_index = {}
-            with open(embeddings_path) as f:
-                for line in f:
-                    word, coefs = line.split(maxsplit=1)
-                    coefs = np.fromstring(coefs, "f", sep=" ")
-                    embeddings_index[word] = coefs
-        elif word_vectors:
-            if word_vectors == 'glove':
-                embeddings_index = api.load("glove-twitter-25")
+    def build_embedding_matrix(self, embeddings_path=None, word_vectors=None):
+        """
+        Builds an embedding matrix from either a local embeddings path
+        or a gensim pre-trained word vector path
 
-        emb_dim = len(coefs)
+        Args:
+            embeddings_path: A local directory to word embeddings
+            word_vectors: The name of a GenSim pre-trained word vector model
+                e.g. 'glove-twitter-25', for the complete list:
+                https://github.com/RaRe-Technologies/gensim-data#models
+
+        Returns:
+            An embedding matrix
+
+        """
+        if embeddings_path:
+            if path.exists(embeddings_path):
+                embeddings_index = {}
+                with open(embeddings_path) as f:
+                    for line in f:
+                        word, coefs = line.split(maxsplit=1)
+                        coefs = np.fromstring(coefs, "f", sep=" ")
+                        embeddings_index[word] = coefs
+                    emb_dim = len(coefs)
+            else:
+                logger.error(
+                    "Incorrect local embeddings path"
+                    )
+                return
+        elif word_vectors:
+            try:
+                embeddings_index = api.load(word_vectors)
+                emb_dim = embeddings_index.vector_size
+            except ValueError:
+                logger.error(
+                    "Incorrect GenSim word vector model name, try e.g. 'glove-twitter-25'"
+                    )
+                return
+        else:
+            logger.error("No local or GenSim word embeddings given")
+            return
+
         num_words = len(self.tokenizer.word_index) + 1
 
         embedding_matrix = np.zeros((num_words, emb_dim))
         for word, i in self.tokenizer.word_index.items():
-            embedding_vector = embeddings_index.get(word)
+            if embeddings_path:
+                embedding_vector = embeddings_index.get(word)
+            else:
+                # get_vector will error if the word isn't in the vocab 
+                try:
+                    embedding_vector = embeddings_index.get_vector(word)
+                except KeyError:
+                    embedding_vector = None
             if embedding_vector is not None:
                 # words not found in embedding index will be all-zeros.
                 embedding_matrix[i] = embedding_vector

--- a/wellcomeml/ml/keras_vectorizer.py
+++ b/wellcomeml/ml/keras_vectorizer.py
@@ -4,6 +4,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from tensorflow.keras.preprocessing.text import Tokenizer
 from tensorflow.keras.preprocessing.sequence import pad_sequences
 import numpy as np
+import gensim.downloader as api
 
 
 class KerasVectorizer(BaseEstimator, TransformerMixin):
@@ -21,13 +22,17 @@ class KerasVectorizer(BaseEstimator, TransformerMixin):
         sequences = self.tokenizer.texts_to_sequences(X)
         return pad_sequences(sequences, maxlen=self.sequence_length)
 
-    def build_embedding_matrix(self, embeddings_path):
-        embeddings_index = {}
-        with open(embeddings_path) as f:
-            for line in f:
-                word, coefs = line.split(maxsplit=1)
-                coefs = np.fromstring(coefs, "f", sep=" ")
-                embeddings_index[word] = coefs
+    def build_embedding_matrix(self, embeddings_path, word_vectors='glove'):
+        if my_file.exists(embeddings_path):
+            embeddings_index = {}
+            with open(embeddings_path) as f:
+                for line in f:
+                    word, coefs = line.split(maxsplit=1)
+                    coefs = np.fromstring(coefs, "f", sep=" ")
+                    embeddings_index[word] = coefs
+        elif word_vectors:
+            if word_vectors == 'glove':
+                embeddings_index = api.load("glove-twitter-25")
 
         emb_dim = len(coefs)
         num_words = len(self.tokenizer.word_index) + 1

--- a/wellcomeml/ml/keras_vectorizer.py
+++ b/wellcomeml/ml/keras_vectorizer.py
@@ -10,6 +10,7 @@ from os import path
 
 from wellcomeml.logger import logger
 
+
 class KerasVectorizer(BaseEstimator, TransformerMixin):
     def __init__(self, vocab_size=None, sequence_length=None, oov_token="<OOV>"):
         self.vocab_size = vocab_size
@@ -50,9 +51,7 @@ class KerasVectorizer(BaseEstimator, TransformerMixin):
                         embeddings_index[word] = coefs
                     emb_dim = len(coefs)
             else:
-                logger.error(
-                    "Incorrect local embeddings path"
-                    )
+                logger.error("Incorrect local embeddings path")
                 return
         elif word_vectors:
             try:
@@ -61,7 +60,7 @@ class KerasVectorizer(BaseEstimator, TransformerMixin):
             except ValueError:
                 logger.error(
                     "Incorrect GenSim word vector model name, try e.g. 'glove-twitter-25'"
-                    )
+                )
                 return
         else:
             logger.error("No local or GenSim word embeddings given")
@@ -74,7 +73,7 @@ class KerasVectorizer(BaseEstimator, TransformerMixin):
             if embeddings_path:
                 embedding_vector = embeddings_index.get(word)
             else:
-                # get_vector will error if the word isn't in the vocab 
+                # get_vector will error if the word isn't in the vocab
                 try:
                     embedding_vector = embeddings_index.get_vector(word)
                 except KeyError:


### PR DESCRIPTION
Description
---

Fixing https://github.com/wellcometrust/WellcomeML/issues/35

I can't actually see any usage of the "build_embedding_matrix" function in other projects, so I'm hoping setting `embeddings_path=None` doesn't break anything.

I've set it so that the function can take a gensim word vector name if the local path isn't given. But can change the logic if this isn't ideal, I wasn't sure whether it'd be better to just give a default model name?

Checklist
---

- [ ] Added link to Github issue or Trello card
- [ ] Added tests
