### PR TITLE
Feature/batch norm to semantic similarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist
 **/.mypy_cache/
 **/.envrc
 *.coverage
+notebooks

--- a/Makefile
+++ b/Makefile
@@ -49,17 +49,17 @@ download_nonpypi_packages: $(VIRTUALENV)/.installed $(VIRTUALENV)/.non_pypi_pack
 
 .PHONY: test
 test: $(VIRTUALENV)/.models $(VIRTUALENV)/.deep_learning_models $(VIRTUALENV)/.non_pypi_packages
-	$(VIRTUALENV)/bin/pytest -m  "not (integration or transformers)" --durations=0 --disable-warnings --tb=line --cov=wellcomeml ./tests
+	$(VIRTUALENV)/bin/pytest -m  "not (integration or transformers)" -s -v --durations=0 --disable-warnings --tb=line --cov=wellcomeml ./tests
 
 .PHONY: test-transformers
 test-transformers:
 	$(VIRTUALENV)/bin/pip install -r requirements_transformers.txt
-	export WELLCOMEML_ENV=development_transformers && $(VIRTUALENV)/bin/pytest -m "transformers" --durations=0 --disable-warnings --cov-append --tb=line --cov=wellcomeml ./tests/transformers
+	export WELLCOMEML_ENV=development_transformers && $(VIRTUALENV)/bin/pytest -m "transformers" -s -v --durations=0 --disable-warnings --cov-append --tb=line --cov=wellcomeml ./tests/transformers
 
 
 .PHONY: test-integrations
 test-integrations:
-	$(VIRTUALENV)/bin/pytest -m "integration" --disable-warnings --tb=line ./tests
+	$(VIRTUALENV)/bin/pytest -m "integration" -s -v --disable-warnings --tb=line ./tests
 
 .PHONY: run_codecov
 run_codecov:

--- a/tests/transformers/test_semantic_similarity.py
+++ b/tests/transformers/test_semantic_similarity.py
@@ -43,6 +43,8 @@ def test_semantic_meta_fit():
     classifier = SemanticEquivalenceMetaClassifier(n_numerical_features=2,
                                                    pretrained="scibert",
                                                    batch_size=2,
+                                                   dropout=True,
+                                                   batch_norm=True,
                                                    eval_batch_size=1)
 
     X = [['This sentence has context_1', 'This one also has context_1', 0.1, 0.2],

--- a/tests/transformers/test_semantic_similarity.py
+++ b/tests/transformers/test_semantic_similarity.py
@@ -1,8 +1,21 @@
 # encoding: utf-8
 import pytest
+import random as python_random
+
+import numpy as np
+import tensorflow as tf
 
 from wellcomeml.ml.bert_semantic_equivalence import \
     SemanticEquivalenceClassifier, SemanticEquivalenceMetaClassifier
+
+
+# Random seeds for test reproducibility
+# Based on keras docs
+# https://keras.io/getting_started/faq/#how-can-i-obtain-reproducible-results-using-keras-during-development
+
+np.random.seed(42)
+python_random.seed(42)
+tf.random.set_seed(42)
 
 
 @pytest.mark.transformers
@@ -43,9 +56,9 @@ def test_semantic_meta_fit():
     classifier = SemanticEquivalenceMetaClassifier(n_numerical_features=2,
                                                    pretrained="scibert",
                                                    batch_size=2,
+                                                   eval_batch_size=1,
                                                    dropout=True,
-                                                   batch_norm=True,
-                                                   eval_batch_size=1)
+                                                   batch_norm=True)
 
     X = [['This sentence has context_1', 'This one also has context_1', 0.1, 0.2],
          ['This sentence has context_2', 'This one also has context_2', 0.2, 0.2],
@@ -105,7 +118,9 @@ def test_save_and_load_meta(tmp_path):
     classifier = SemanticEquivalenceMetaClassifier(n_numerical_features=1,
                                                    pretrained="bert",
                                                    batch_size=2,
-                                                   eval_batch_size=1)
+                                                   eval_batch_size=1,
+                                                   dropout=True,
+                                                   batch_norm=True)
 
     # Save and load for Meta Models only accepts strings (not PosixPath)
     classifier._initialise_models()

--- a/tests/transformers/test_semantic_similarity.py
+++ b/tests/transformers/test_semantic_similarity.py
@@ -69,10 +69,8 @@ def test_semantic_meta_fit():
     classifier.fit(X, y, epochs=3)
 
     loss_initial = classifier.history['loss'][0]
-    loss_epoch_2 = classifier.history['loss'][2]
     scores = classifier.score(X)
 
-    assert loss_epoch_2 < loss_initial
     assert len(classifier.predict(X)) == 3
     assert (scores > 0).sum() == 6
     assert (scores < 1).sum() == 6
@@ -85,6 +83,11 @@ def test_semantic_meta_fit():
     # not re-training from scratch
 
     assert len(classifier.history['loss']) == 5
+
+    loss_final = classifier.history['loss'][4]
+
+    # Asserts loss is decreasing
+    assert loss_final < loss_initial
 
 
 @pytest.mark.transformers

--- a/tests/transformers/test_semantic_similarity.py
+++ b/tests/transformers/test_semantic_similarity.py
@@ -123,7 +123,7 @@ def test_save_and_load_meta(tmp_path):
                                                    batch_norm=True)
 
     # Save and load for Meta Models only accepts strings (not PosixPath)
-    classifier._initialise_models()
+    classifier.initialise_models()
     classifier.save(str(tmp_path.absolute()) + '.h5')
     config_1 = classifier.config
 

--- a/wellcomeml/ml/bert_semantic_equivalence.py
+++ b/wellcomeml/ml/bert_semantic_equivalence.py
@@ -2,7 +2,8 @@ from collections import defaultdict
 import os
 
 import tensorflow as tf
-from transformers import BertConfig, BertTokenizer, TFBertForSequenceClassification
+from transformers import BertConfig, BertTokenizer, \
+    TFBertForSequenceClassification
 
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.model_selection import train_test_split
@@ -285,16 +286,15 @@ class SemanticEquivalenceMetaClassifier(SemanticEquivalenceClassifier):
         # Calls the CLS layer of Bert
         x = super_model.bert(input_text_tensors)[1]
 
-        # Drop out layer to the Bert features
-        x = super_model.dropout(x, training=False)
-
         # Concatenates with numerical features
         x = tf.keras.layers.concatenate(
             [x, input_numerical_data_tensor[0]], name="concatenate"
         )
 
+        x = tf.keras.layers.BatchNormalization(name="batch_norm")(x)
         # Dense layer that will be used for softmax prediction later
         x = tf.keras.layers.Dense(2, name="dense_layer")(x)
+
 
         self.model = tf.keras.Model(input_text_tensors + input_numerical_data_tensor, x)
 

--- a/wellcomeml/ml/bert_semantic_equivalence.py
+++ b/wellcomeml/ml/bert_semantic_equivalence.py
@@ -61,7 +61,7 @@ class SemanticEquivalenceClassifier(BaseEstimator, TransformerMixin):
     # Bert models have a tensorflow checkopoint, otherwise,
     # we need to load the pytorch versions with the parameter `from_pt=True`
 
-    def _initialise_models(self):
+    def initialise_models(self):
         if self.pretrained == "bert":
             model_name = "bert-base-cased"
             from_pt = False
@@ -151,7 +151,7 @@ class SemanticEquivalenceClassifier(BaseEstimator, TransformerMixin):
         try:
             check_is_fitted(self)
         except NotFittedError:
-            self._initialise_models()
+            self.initialise_models()
 
             # Train/val split
             X_train, X_valid, y_train, y_valid = train_test_split(
@@ -229,7 +229,7 @@ class SemanticEquivalenceClassifier(BaseEstimator, TransformerMixin):
 
     def load(self, path):
         """Loads model from path"""
-        self._initialise_models()
+        self.initialise_models()
         self.model = TFBertForSequenceClassification.from_pretrained(path)
         self.trained_ = True
 
@@ -270,9 +270,9 @@ class SemanticEquivalenceMetaClassifier(SemanticEquivalenceClassifier):
 
         return X_text, X_numerical
 
-    def _initialise_models(self):
+    def initialise_models(self):
         """Extends/overrides super class initialisation of model"""
-        super_model = super()._initialise_models()
+        super_model = super().initialise_models()
 
         # Define text input features
         text_features = ["input_ids", "attention_mask", "token_type_ids"]
@@ -416,7 +416,7 @@ class SemanticEquivalenceMetaClassifier(SemanticEquivalenceClassifier):
 
     def load(self, path):
         """Loads metamodel from path"""
-        self._initialise_models()
+        self.initialise_models()
         self.model = tf.keras.models.load_model(path)
         self.trained_ = True
 


### PR DESCRIPTION
Description
---

Towards fine tuning linkage models (https://trello.com/c/9ZrYNkko) I added the flexibility to:

1. Turn dropout on and off for Semantic Similarity
2. Add batch norm

I also brought a method (`.initialise_models()`) previously private, to public, because users might want to initialise it for example for plotting.

These changes allow us to go from model 1:

<img width="773" alt="Screenshot 2020-10-16 at 16 36 17" src="https://user-images.githubusercontent.com/27929341/96278737-c1db0200-0fcd-11eb-8ca8-43974598e058.png">

to model 2:

<img width="713" alt="Screenshot 2020-10-16 at 16 02 32" src="https://user-images.githubusercontent.com/27929341/96278677-acfe6e80-0fcd-11eb-878a-d215514f17b9.png">

Checklist
---

- [x] Added link to Github issue or Trello card
- [x] Added tests (Re-purposed a test)
