### PR TITLE
Multi gpu predict

### DIFF
--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -218,11 +218,11 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
             Y_pred = vstack(Y_pred)
             return Y_pred
         else:
-            return self.model.predict(X).numpy() > self.threshold
+            return self.model.predict(X, self.batch_size).numpy() > self.threshold
 
     def predict_proba(self, X):
         # sparse_y not relevant as probs are dense
-        return self.model.predict(X).numpy()
+        return self.model.predict(X, self.batch_size).numpy()
 
     def score(self, X, Y):
         if isinstance(X, list):

--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -236,4 +236,9 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
         self.model.save(model_dir)
 
     def load(self, model_dir):
-        self.model = tf.keras.models.load_model(model_dir)
+        if tf.config.list_physical_devices('GPU'):
+            strategy = tf.distribute.MirroredStrategy()
+        else:  # use default strategy
+            strategy = tf.distribute.get_strategy()
+        with strategy.scope():
+            self.model = tf.keras.models.load_model(model_dir)

--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -236,7 +236,7 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
         self.model.save(model_dir)
 
     def load(self, model_dir):
-        if tf.config.list_physical_devices('GPU'):
+        if len(tf.config.list_physical_devices('GPU')) > 1:
             strategy = tf.distribute.MirroredStrategy()
         else:  # use default strategy
             strategy = tf.distribute.get_strategy()

--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -213,16 +213,16 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
             Y_pred = []
             for i in range(0, X.shape[0], self.batch_size):
                 X_batch = X[i: i+self.batch_size]
-                Y_pred_batch = self.model(X_batch) > self.threshold
+                Y_pred_batch = self.model.predict(X_batch) > self.threshold
                 Y_pred.append(csr_matrix(Y_pred_batch))
             Y_pred = vstack(Y_pred)
             return Y_pred
         else:
-            return self.model(X).numpy() > self.threshold
+            return self.model.predict(X).numpy() > self.threshold
 
     def predict_proba(self, X):
         # sparse_y not relevant as probs are dense
-        return self.model(X).numpy()
+        return self.model.predict(X).numpy()
 
     def score(self, X, Y):
         if isinstance(X, list):

--- a/wellcomeml/ml/bilstm.py
+++ b/wellcomeml/ml/bilstm.py
@@ -218,11 +218,11 @@ class BiLSTMClassifier(BaseEstimator, ClassifierMixin):
             Y_pred = vstack(Y_pred)
             return Y_pred
         else:
-            return self.model.predict(X, self.batch_size).numpy() > self.threshold
+            return self.model.predict(X, self.batch_size) > self.threshold
 
     def predict_proba(self, X):
         # sparse_y not relevant as probs are dense
-        return self.model.predict(X, self.batch_size).numpy()
+        return self.model.predict(X, self.batch_size)
 
     def score(self, X, Y):
         if isinstance(X, list):

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -269,4 +269,9 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         self.model.save(model_dir)
 
     def load(self, model_dir):
-        self.model = tf.keras.models.load_model(model_dir)
+        if tf.config.list_physical_devices('GPU'):
+            strategy = tf.distribute.MirroredStrategy()
+        else:  # use default strategy
+            strategy = tf.distribute.get_strategy()
+        with strategy.scope():
+            self.model = tf.keras.models.load_model(model_dir)

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -253,11 +253,11 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             Y_pred = vstack(Y_pred)
             return Y_pred
         else:
-            return self.model.predict(X, self.batch_size).numpy() > self.threshold
+            return self.model.predict(X, self.batch_size) > self.threshold
 
     def predict_proba(self, X):
         # sparse_y not relevant as probs are dense
-        return self.model.predict(X, self.batch_size).numpy()
+        return self.model.predict(X, self.batch_size)
 
     def score(self, X, Y):
         if isinstance(X, list):

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -271,7 +271,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         self.model.save(model_dir)
 
     def load(self, model_dir):
-        if tf.config.list_physical_devices('GPU'):
+        if len(tf.config.list_physical_devices('GPU')) > 1:
             strategy = tf.distribute.MirroredStrategy()
         else:  # use default strategy
             strategy = tf.distribute.get_strategy()

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -91,6 +91,13 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
                     Y_batch = Y_batch.todense()
                 yield X_batch, Y_batch
 
+    def _get_distributed_strategy(self):
+        if len(tf.config.list_physical_devices('GPU')) > 1:
+            strategy = tf.distribute.MirroredStrategy()
+        else:  # use default strategy
+            strategy = tf.distribute.get_strategy()
+        return strategy
+
     def _build_model(self, sequence_length, vocab_size, nb_outputs,
                      steps_per_epoch, embedding_matrix=None,
                      metrics=["precision", "recall"]):
@@ -173,7 +180,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             self.learning_rate, steps_per_epoch, self.learning_rate_decay,
             staircase=True
         )
-        strategy = tf.distribute.get_strategy()
+        strategy = self._get_distributed_strategy()
         if isinstance(strategy, tf.distribute.MirroredStrategy):
             optimizer = tf.keras.optimizers.Adam(learning_rate)
         else:  # clipnorm is only supported in default strategy
@@ -200,10 +207,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         steps_per_epoch = math.ceil(X_train.shape[0] / self.batch_size)
         validation_steps = math.ceil(X_val.shape[0] / self.batch_size)
 
-        if len(tf.config.list_physical_devices('GPU')) > 1:
-            strategy = tf.distribute.MirroredStrategy()
-        else:  # use default strategy
-            strategy = tf.distribute.get_strategy()
+        strategy = self._get_distributed_strategy()
         with strategy.scope():
             self.model = self._build_model(
                 sequence_length, vocab_size, nb_outputs,
@@ -271,9 +275,6 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         self.model.save(model_dir)
 
     def load(self, model_dir):
-        if len(tf.config.list_physical_devices('GPU')) > 1:
-            strategy = tf.distribute.MirroredStrategy()
-        else:  # use default strategy
-            strategy = tf.distribute.get_strategy()
+        strategy = self._get_distributed_strategy()
         with strategy.scope():
             self.model = tf.keras.models.load_model(model_dir)

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -246,16 +246,16 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             Y_pred = []
             for i in range(0, X.shape[0], self.batch_size):
                 X_batch = X[i: i+self.batch_size]
-                Y_pred_batch = self.model(X_batch) > self.threshold
+                Y_pred_batch = self.model.predict(X_batch) > self.threshold
                 Y_pred.append(csr_matrix(Y_pred_batch))
             Y_pred = vstack(Y_pred)
             return Y_pred
         else:
-            return self.model(X).numpy() > self.threshold
+            return self.model.predict(X).numpy() > self.threshold
 
     def predict_proba(self, X):
         # sparse_y not relevant as probs are dense
-        return self.model(X).numpy()
+        return self.model.predict(X).numpy()
 
     def score(self, X, Y):
         if isinstance(X, list):

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -246,16 +246,18 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             Y_pred = []
             for i in range(0, X.shape[0], self.batch_size):
                 X_batch = X[i: i+self.batch_size]
+                # we do not pass batch_size in predict to allow batches to spead
+                # cores or multi gpu by setting high batch_size vs default 32
                 Y_pred_batch = self.model.predict(X_batch) > self.threshold
                 Y_pred.append(csr_matrix(Y_pred_batch))
             Y_pred = vstack(Y_pred)
             return Y_pred
         else:
-            return self.model.predict(X).numpy() > self.threshold
+            return self.model.predict(X, self.batch_size).numpy() > self.threshold
 
     def predict_proba(self, X):
         # sparse_y not relevant as probs are dense
-        return self.model.predict(X).numpy()
+        return self.model.predict(X, self.batch_size).numpy()
 
     def score(self, X, Y):
         if isinstance(X, list):


### PR DESCRIPTION
Description
---

This PR adds the ability to use multiple GPUs for predict. Since I implemented this I found out that 1GPU is enough in MeSH for prediction but I do not see a harm in adding that. What it will do is, if there are multiple GPUs it will use them in the same way that the default behaviour for fit us to use as many CPUs and GPUs are available

Checklist
---

- [ ] Added link to Github issue or Trello card
- [ ] Added tests
