### PR TITLE
new: Add f1 metric and loss functions and GlobalF1 callback (fixes #172)

### DIFF
--- a/tests/metrics/test_f1.py
+++ b/tests/metrics/test_f1.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-import os
-import tempfile
-
 import numpy as np
-
 import pytest
 import tensorflow as tf
+
 from wellcomeml.metrics import f1_loss, f1_metric
 
 
@@ -85,7 +82,9 @@ def test_f1_metric(data, model):
     """ Test whether the f1_metrics are output"""
 
     model.compile(
-        loss="binary_crossentropy", optimizer="adam", metrics=[f1_metric],
+        loss="binary_crossentropy",
+        optimizer="adam",
+        metrics=[f1_metric],
     )
 
     history = model.fit(
@@ -106,10 +105,12 @@ def test_f1_loss(data, model):
     """ Test to see if it runs, don't test the loss itself """
 
     model.compile(
-        loss=f1_loss, optimizer="adam", metrics=["accuracy"],
+        loss=f1_loss,
+        optimizer="adam",
+        metrics=["accuracy"],
     )
 
-    history = model.fit(
+    model.fit(
         data["X_train"],
         data["y_train"],
         epochs=5,
@@ -117,5 +118,3 @@ def test_f1_loss(data, model):
         batch_size=1024,
         verbose=0,
     )
-
-

--- a/tests/metrics/test_f1.py
+++ b/tests/metrics/test_f1.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import pytest
 import tensorflow as tf
-from wellcomeml.metrics import GlobalF1, f1_loss, f1_metric
+from wellcomeml.metrics import f1_loss, f1_metric
 
 
 @pytest.fixture(scope="module")
@@ -119,26 +119,3 @@ def test_f1_loss(data, model):
     )
 
 
-def test_globalf1_callback(data, model, tmpdir):
-
-    history_path = os.path.join(tmpdir, "test_f1.csv")
-
-    model.compile(
-        loss=f1_loss, optimizer="adam", metrics=["accuracy"],
-    )
-
-    metrics = GlobalF1(
-        validation=(data["X_test"], data["y_test"]), history_path=history_path
-    )
-
-    history = model.fit(
-        data["X_train"],
-        data["y_train"],
-        epochs=5,
-        validation_data=(data["X_test"], data["y_test"]),
-        batch_size=1024,
-        verbose=0,
-        callbacks=[metrics],
-    )
-
-    assert os.path.exists(history_path)

--- a/tests/metrics/test_f1.py
+++ b/tests/metrics/test_f1.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import os
+import tempfile
+
+import numpy as np
+
+import pytest
+import tensorflow as tf
+from wellcomeml.metrics import GlobalF1, f1_loss, f1_metric
+
+
+@pytest.fixture(scope="module")
+def tmpdir(tmpdir_factory):
+    return tmpdir_factory.mktemp("test_f1")
+
+
+@pytest.fixture(scope="module")
+def data():
+    X_train = np.random.random((100, 10))
+    y_train = np.random.random(100).astype(int)
+
+    X_test = np.random.random((100, 10))
+    y_test = np.random.random(100).astype(int)
+
+    return {"X_train": X_train, "y_train": y_train, "X_test": X_test, "y_test": y_test}
+
+
+@pytest.fixture(scope="module")
+def model():
+    inputs = tf.keras.Input(shape=(10,))
+    x = tf.keras.layers.Dense(128, activation="relu")(inputs)
+    outputs = tf.keras.layers.Dense(1, "sigmoid")(x)
+    model = tf.keras.Model(inputs=inputs, outputs=outputs)
+
+    return model
+
+
+def test_f1_metric_all_true():
+
+    y_true = [0, 1, 1, 0]
+    y_pred = [0, 1, 1, 0]
+
+    f1 = f1_metric(y_true, y_pred)
+
+    assert isinstance(f1, tf.Tensor)
+    assert f1 == 1.0
+
+
+def test_f1_metric_all_false():
+
+    y_true = [0, 1, 1, 0]
+    y_pred = [0, 0, 0, 0]
+
+    f1 = f1_metric(y_true, y_pred)
+
+    assert isinstance(f1, tf.Tensor)
+    assert f1 == 0.0
+
+
+def test_f1_metric_poor_recall():
+
+    y_true = [0, 1, 1, 0]
+    y_pred = [0, 1, 0, 0]
+
+    f1 = f1_metric(y_true, y_pred)
+
+    assert isinstance(f1, tf.Tensor)
+    assert f1 == 0.66666657
+
+
+def test_f1_metric_poor_precision():
+
+    y_true = [0, 1, 1, 0]
+    y_pred = [1, 0, 0, 0]
+
+    f1 = f1_metric(y_true, y_pred)
+
+    assert isinstance(f1, tf.Tensor)
+    assert f1 == 0.0
+
+
+def test_f1_metric(data, model):
+    """ Test whether the f1_metrics are output"""
+
+    model.compile(
+        loss="binary_crossentropy", optimizer="adam", metrics=[f1_metric],
+    )
+
+    history = model.fit(
+        data["X_train"],
+        data["y_train"],
+        epochs=5,
+        validation_data=(data["X_test"], data["y_test"]),
+        batch_size=1024,
+        verbose=0,
+    )
+
+    assert set(history.history.keys()) == set(
+        ["loss", "f1_metric", "val_loss", "val_f1_metric"]
+    )
+
+
+def test_f1_loss(data, model):
+    """ Test to see if it runs, don't test the loss itself """
+
+    model.compile(
+        loss=f1_loss, optimizer="adam", metrics=["accuracy"],
+    )
+
+    history = model.fit(
+        data["X_train"],
+        data["y_train"],
+        epochs=5,
+        validation_data=(data["X_test"], data["y_test"]),
+        batch_size=1024,
+        verbose=0,
+    )
+
+
+def test_globalf1_callback(data, model, tmpdir):
+
+    history_path = os.path.join(tmpdir, "test_f1.csv")
+
+    model.compile(
+        loss=f1_loss, optimizer="adam", metrics=["accuracy"],
+    )
+
+    metrics = GlobalF1(
+        validation=(data["X_test"], data["y_test"]), history_path=history_path
+    )
+
+    history = model.fit(
+        data["X_train"],
+        data["y_train"],
+        epochs=5,
+        validation_data=(data["X_test"], data["y_test"]),
+        batch_size=1024,
+        verbose=0,
+        callbacks=[metrics],
+    )
+
+    assert os.path.exists(history_path)

--- a/tests/ml/test_keras_utils.py
+++ b/tests/ml/test_keras_utils.py
@@ -2,12 +2,11 @@
 # coding: utf-8
 
 import os
-import tempfile
 
 import numpy as np
-
 import pytest
 import tensorflow as tf
+
 from wellcomeml.ml.keras_utils import Metrics
 
 
@@ -42,14 +41,16 @@ def test_metrics_callback(data, model, tmpdir):
     history_path = os.path.join(tmpdir, "test_f1.csv")
 
     model.compile(
-        loss="binary_crossentropy", optimizer="adam", metrics=["accuracy"],
+        loss="binary_crossentropy",
+        optimizer="adam",
+        metrics=["accuracy"],
     )
 
     metrics = Metrics(
         validation_data=(data["X_test"], data["y_test"]), history_path=history_path
     )
 
-    history = model.fit(
+    model.fit(
         data["X_train"],
         data["y_train"],
         epochs=5,

--- a/tests/ml/test_keras_utils.py
+++ b/tests/ml/test_keras_utils.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import os
+import tempfile
+
+import numpy as np
+
+import pytest
+import tensorflow as tf
+from wellcomeml.ml.keras_utils import Metrics
+
+
+@pytest.fixture(scope="module")
+def tmpdir(tmpdir_factory):
+    return tmpdir_factory.mktemp("test_f1")
+
+
+@pytest.fixture(scope="module")
+def data():
+    X_train = np.random.random((100, 10))
+    y_train = np.random.random(100).astype(int)
+
+    X_test = np.random.random((100, 10))
+    y_test = np.random.random(100).astype(int)
+
+    return {"X_train": X_train, "y_train": y_train, "X_test": X_test, "y_test": y_test}
+
+
+@pytest.fixture(scope="module")
+def model():
+    inputs = tf.keras.Input(shape=(10,))
+    x = tf.keras.layers.Dense(128, activation="relu")(inputs)
+    outputs = tf.keras.layers.Dense(1, "sigmoid")(x)
+    model = tf.keras.Model(inputs=inputs, outputs=outputs)
+
+    return model
+
+
+def test_metrics_callback(data, model, tmpdir):
+
+    history_path = os.path.join(tmpdir, "test_f1.csv")
+
+    model.compile(
+        loss="binary_crossentropy", optimizer="adam", metrics=["accuracy"],
+    )
+
+    metrics = Metrics(
+        validation_data=(data["X_test"], data["y_test"]), history_path=history_path
+    )
+
+    history = model.fit(
+        data["X_train"],
+        data["y_train"],
+        epochs=5,
+        validation_data=(data["X_test"], data["y_test"]),
+        batch_size=1024,
+        verbose=0,
+        callbacks=[metrics],
+    )
+
+    assert os.path.exists(history_path)

--- a/wellcomeml/metrics/__init__.py
+++ b/wellcomeml/metrics/__init__.py
@@ -1,3 +1,4 @@
+from .f1 import GlobalF1, f1_loss, f1_metric
 from .ner_classification_report import ner_classification_report
 
-__all__ = ['ner_classification_report']
+__all__ = ["ner_classification_report", "f1_metric", "f1_loss", "GlobalF1"]

--- a/wellcomeml/metrics/__init__.py
+++ b/wellcomeml/metrics/__init__.py
@@ -1,4 +1,4 @@
-from .f1 import GlobalF1, f1_loss, f1_metric
+from .f1 import f1_loss, f1_metric
 from .ner_classification_report import ner_classification_report
 
-__all__ = ["ner_classification_report", "f1_metric", "f1_loss", "GlobalF1"]
+__all__ = ["ner_classification_report", "f1_metric", "f1_loss"]

--- a/wellcomeml/metrics/f1.py
+++ b/wellcomeml/metrics/f1.py
@@ -37,14 +37,4 @@ def f1_loss(y_true, y_pred):
     >>>     metrics=["accuracy"]
     >>> )
     """
-    y_true = K.cast(y_true, "float")
-    y_pred = K.cast(y_pred, "float")
-    tp = K.sum(K.cast(y_true * y_pred, "float"), axis=0)
-    fp = K.sum(K.cast((1 - y_true) * y_pred, "float"), axis=0)
-    fn = K.sum(K.cast(y_true * (1 - y_pred), "float"), axis=0)
-    p = tp / (tp + fp + K.epsilon())
-    r = tp / (tp + fn + K.epsilon())
-    f1 = 2 * p * r / (p + r + K.epsilon())
-    f1 = tf.where(tf.math.is_nan(f1), tf.zeros_like(f1), f1)
-
-    return 1 - K.mean(f1)
+    return 1 - f1_metric(y_true, y_pred)

--- a/wellcomeml/metrics/f1.py
+++ b/wellcomeml/metrics/f1.py
@@ -1,0 +1,113 @@
+""" Whole test set and batchwise f1 metrics for use with keras
+
+Adapted from: https://www.kaggle.com/rejpalcz/best-loss-function-for-f1-score-metric
+"""
+import numpy as np
+
+import pandas as pd
+import tensorflow as tf
+import tensorflow.keras.backend as K
+from sklearn.metrics import f1_score, precision_score, recall_score
+from tensorflow.keras.callbacks import Callback
+
+
+def f1_metric(y_true, y_pred):
+    """Calculate batchwise macro f1
+
+    >>> model.compile(
+    >>>     loss="binary_crossentropy",
+    >>>     optimizer="adam",
+    >>>     metrics=["accuracy", f1_metric]
+    >>> )
+    """
+    y_true = K.cast(y_true, "float")
+    y_pred = K.cast(y_pred, "float")
+    tp = K.sum(K.cast(y_true * y_pred, "float"), axis=0)
+    fp = K.sum(K.cast((1 - y_true) * y_pred, "float"), axis=0)
+    fn = K.sum(K.cast(y_true * (1 - y_pred), "float"), axis=0)
+    p = tp / (tp + fp + K.epsilon())
+    r = tp / (tp + fn + K.epsilon())
+    f1 = 2 * p * r / (p + r + K.epsilon())
+    f1 = tf.where(tf.math.is_nan(f1), tf.zeros_like(f1), f1)
+
+    return K.mean(f1)
+
+
+def f1_loss(y_true, y_pred):
+    """Generate batchwise macro f1 loss
+
+    >>> model.compile(
+    >>>     loss=f1_loss,
+    >>>     optimizer="adam",
+    >>>     metrics=["accuracy"]
+    >>> )
+    """
+    y_true = K.cast(y_true, "float")
+    y_pred = K.cast(y_pred, "float")
+    tp = K.sum(K.cast(y_true * y_pred, "float"), axis=0)
+    fp = K.sum(K.cast((1 - y_true) * y_pred, "float"), axis=0)
+    fn = K.sum(K.cast(y_true * (1 - y_pred), "float"), axis=0)
+    p = tp / (tp + fp + K.epsilon())
+    r = tp / (tp + fn + K.epsilon())
+    f1 = 2 * p * r / (p + r + K.epsilon())
+    f1 = tf.where(tf.math.is_nan(f1), tf.zeros_like(f1), f1)
+
+    return 1 - K.mean(f1)
+
+
+class GlobalF1(Callback):
+    """Calculate global F1, precision, and recall, against a complete test set
+    not just batch level metrics as with f1_metric.
+
+    >>> global_f1 = GlobalF1(validation=(X_test, y_test, history.csv))
+    >>>
+    >>> history = model.fit(
+    >>>     X_train,
+    >>>     y_train,
+    >>>     epochs=100,
+    >>>     validation_data=(X_test, y_test),
+    >>>     batch_size=1024,
+    >>>     verbose=2,
+    >>>     callbacks=[early_stopping, glbal_f1],
+    >>> )
+    """
+
+    def __init__(self, validation, history_path: str = None):
+        super(GlobalF1, self).__init__()
+        self.validation = validation
+        self.history_path = history_path
+
+    def on_train_begin(self, logs={}):
+        self.val_f1s = []
+        self.val_recalls = []
+        self.val_precisions = []
+
+    def on_epoch_end(self, epoch, logs={}):
+        val_targ = self.validation[1]
+        val_predict = (np.asarray(self.model.predict(self.validation[0]))).round()
+
+        val_f1 = f1_score(val_targ, val_predict)
+        val_recall = recall_score(val_targ, val_predict)
+        val_precision = precision_score(val_targ, val_predict)
+
+        self.val_f1s.append(round(val_f1, 6))
+        self.val_recalls.append(round(val_recall, 6))
+        self.val_precisions.append(round(val_precision, 6))
+
+        print(
+            "Global metrics "
+            f"— val_f1: {round(val_f1,4)} "
+            f"— val_precision: {round(val_precision, 4)} "
+            f"— val_recall: {round(val_recall,4)}"
+        )
+
+    def on_train_end(self, logs={}):
+        """Write metrics to csv file"""
+
+        if self.history_path:
+            history = {}
+            history["f1"] = self.val_f1s
+            history["precision"] = self.val_precisions
+            history["recall"] = self.val_recalls
+            history_df = pd.DataFrame(history)
+            history_df.to_csv(self.history_path, index_label="epoch")

--- a/wellcomeml/metrics/f1.py
+++ b/wellcomeml/metrics/f1.py
@@ -68,7 +68,7 @@ class GlobalF1(Callback):
     >>>     validation_data=(X_test, y_test),
     >>>     batch_size=1024,
     >>>     verbose=2,
-    >>>     callbacks=[early_stopping, glbal_f1],
+    >>>     callbacks=[early_stopping, global_f1],
     >>> )
     """
 

--- a/wellcomeml/metrics/f1.py
+++ b/wellcomeml/metrics/f1.py
@@ -2,13 +2,8 @@
 
 Adapted from: https://www.kaggle.com/rejpalcz/best-loss-function-for-f1-score-metric
 """
-import numpy as np
-
-import pandas as pd
 import tensorflow as tf
 import tensorflow.keras.backend as K
-from sklearn.metrics import f1_score, precision_score, recall_score
-from tensorflow.keras.callbacks import Callback
 
 
 def f1_metric(y_true, y_pred):
@@ -53,61 +48,3 @@ def f1_loss(y_true, y_pred):
     f1 = tf.where(tf.math.is_nan(f1), tf.zeros_like(f1), f1)
 
     return 1 - K.mean(f1)
-
-
-class GlobalF1(Callback):
-    """Calculate global F1, precision, and recall, against a complete test set
-    not just batch level metrics as with f1_metric.
-
-    >>> global_f1 = GlobalF1(validation=(X_test, y_test, history.csv))
-    >>>
-    >>> history = model.fit(
-    >>>     X_train,
-    >>>     y_train,
-    >>>     epochs=100,
-    >>>     validation_data=(X_test, y_test),
-    >>>     batch_size=1024,
-    >>>     verbose=2,
-    >>>     callbacks=[early_stopping, global_f1],
-    >>> )
-    """
-
-    def __init__(self, validation, history_path: str = None):
-        super(GlobalF1, self).__init__()
-        self.validation = validation
-        self.history_path = history_path
-
-    def on_train_begin(self, logs={}):
-        self.val_f1s = []
-        self.val_recalls = []
-        self.val_precisions = []
-
-    def on_epoch_end(self, epoch, logs={}):
-        val_targ = self.validation[1]
-        val_predict = (np.asarray(self.model.predict(self.validation[0]))).round()
-
-        val_f1 = f1_score(val_targ, val_predict)
-        val_recall = recall_score(val_targ, val_predict)
-        val_precision = precision_score(val_targ, val_predict)
-
-        self.val_f1s.append(round(val_f1, 6))
-        self.val_recalls.append(round(val_recall, 6))
-        self.val_precisions.append(round(val_precision, 6))
-
-        print(
-            "Global metrics "
-            f"— val_f1: {round(val_f1,4)} "
-            f"— val_precision: {round(val_precision, 4)} "
-            f"— val_recall: {round(val_recall,4)}"
-        )
-
-    def on_train_end(self, logs={}):
-        """Write metrics to csv file"""
-
-        if self.history_path:
-            history = {}
-            history["f1"] = self.val_f1s
-            history["precision"] = self.val_precisions
-            history["recall"] = self.val_recalls
-            history_df = pd.DataFrame(history)
-            history_df.to_csv(self.history_path, index_label="epoch")

--- a/wellcomeml/ml/keras_utils.py
+++ b/wellcomeml/ml/keras_utils.py
@@ -112,7 +112,7 @@ class CategoricalMetrics(tf.keras.metrics.Metric):
         if self.from_logits:
             y_pred = tf.keras.activations.softmax(y_pred)
 
-        greater_than_threshold = tf.cast(y_pred[:, self.pos :] > self.threshold, "bool")
+        greater_than_threshold = tf.cast(y_pred[:, self.pos:] > self.threshold, "bool")
         positive = tf.cast(y_true, "int32") == self.pos
 
         # Epsilon added to denominators to avoid division by zero

--- a/wellcomeml/ml/keras_utils.py
+++ b/wellcomeml/ml/keras_utils.py
@@ -94,7 +94,7 @@ class CategoricalMetrics(tf.keras.metrics.Metric):
         if self.from_logits:
             y_pred = tf.keras.activations.softmax(y_pred)
 
-        greater_than_threshold = tf.cast(y_pred[:, self.pos :] > self.threshold, "bool")
+        greater_than_threshold = tf.cast(y_pred[:, self.pos:] > self.threshold, "bool")
         positive = tf.cast(y_true, "int32") == self.pos
 
         # Epsilon added to denominators to avoid division by zero

--- a/wellcomeml/ml/keras_utils.py
+++ b/wellcomeml/ml/keras_utils.py
@@ -69,7 +69,8 @@ class Metrics(tf.keras.callbacks.Callback):
 
             with open(self.history_path, mode=mode) as fb:
                 history_writer = csv.writer(fb, delimiter=",")
-                history_writer.writerow(["epoch", "precision", "recall", "f1"])
+                if header:
+                    history_writer.writerow(["epoch", "precision", "recall", "f1"])
 
                 for i, row in enumerate(zip(self.precisions, self.recalls, self.f1s)):
                     history_writer.writerow([i] + list(row))

--- a/wellcomeml/ml/keras_utils.py
+++ b/wellcomeml/ml/keras_utils.py
@@ -21,6 +21,7 @@ class Metrics(tf.keras.callbacks.Callback):
     >>>     callbacks=[early_stopping, metrics],
     >>> )
     """
+
     def __init__(
         self,
         validation,
@@ -57,7 +58,7 @@ class Metrics(tf.keras.callbacks.Callback):
 
     def on_train_end(self, logs={}):
         """Write metrics to csv file"""
-        
+
         if self.history_path:
             mode = "w"
             header = True
@@ -65,17 +66,14 @@ class Metrics(tf.keras.callbacks.Callback):
             if self.append:
                 mode = "a"
                 header = False
-                
+
             history = {}
             history["f1"] = self.f1s
             history["precision"] = self.precisions
             history["recall"] = self.recalls
             history_df = pd.DataFrame(history)
             history_df.to_csv(
-                self.history_path, 
-                index_label="epoch"
-                mode=mode,
-                header=header
+                self.history_path, index_label="epoch", mode=mode, header=header
             )
 
 
@@ -114,7 +112,7 @@ class CategoricalMetrics(tf.keras.metrics.Metric):
         if self.from_logits:
             y_pred = tf.keras.activations.softmax(y_pred)
 
-        greater_than_threshold = tf.cast(y_pred[:, self.pos:] > self.threshold, "bool")
+        greater_than_threshold = tf.cast(y_pred[:, self.pos :] > self.threshold, "bool")
         positive = tf.cast(y_true, "int32") == self.pos
 
         # Epsilon added to denominators to avoid division by zero


### PR DESCRIPTION
## Description
Based on #172:

Adds two new functions:
* f1_metric: A metric for passing into keras `model.compile` which will return the batchwise macro f1 score
* f1_loss: A loss function which can be passed to `model.compile` which will optimise for the batchwise macro f1 score.

Expands the Metrics callback:
* Enables the global f1 history (against a validation set) to be saved for reporting purposes.

## Checklist

- [x] Added link to Github issue or Trello card
- [x] Added tests
