### PR TITLE
Pin dataclasses to 0.6 as required by spacy-transformers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,8 @@ setuptools.setup(
             'tensorflow',
             'torch',
             'transformers<=2.0.0',
-            'spacy-transformers==0.5.1'
+            'spacy-transformers==0.5.1',
+            'dataclasses==0.6' # spacy transformers needs this pinned
         ]
     },
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setuptools.setup(
             'torch',
             'transformers<=2.0.0',
             'spacy-transformers==0.5.1',
-            'dataclasses==0.6' # spacy transformers needs this pinned
+            'dataclasses==0.6'  # spacy transformers needs this pinned
         ]
     },
     tests_require=[


### PR DESCRIPTION
Description
---

Fixes #179 

I did not add tests as tests should have caught that. Not sure why this is not happening?

Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests
