### PR TITLE
Rewrite BertClassifier using transformers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(VIRTUALENV)/.models:
 	touch $@
 
 $(VIRTUALENV)/.deep_learning_models:
-	$(VIRTUALENV)/bin/python -m spacy download en_trf_bertbaseuncased_lg
+#	$(VIRTUALENV)/bin/python -m spacy download en_trf_bertbaseuncased_lg
 	touch $@
 
 $(VIRTUALENV)/.non_pypi_packages:

--- a/examples/bert_classifier.py
+++ b/examples/bert_classifier.py
@@ -5,6 +5,6 @@ from wellcomeml.ml import BertClassifier
 X = ["Hot and cold", "Hot", "Cold"]
 Y = np.array([[1, 1], [1, 0], [0, 1]])
 
-bert = BertClassifier()
+bert = BertClassifier(batch_size=8)
 bert.fit(X, Y)
 print(bert.score(X, Y))

--- a/tests/test_bert_classifier.py
+++ b/tests/test_bert_classifier.py
@@ -33,34 +33,32 @@ def test_multilabel():
     assert model.losses[0] > model.losses[-1]
 
 
-def test_partial_fit():
+def test_multiclass():
     X = [
-        "One and two",
-        "One only",
-        "Three and four, nothing else",
-        "Two nothing else",
-        "Two and three"
+        "One oh yes",
+        "Two noo",
+        "Three ok",
+        "one fantastic",
+        "two bad"
     ]
-    Y = [
-        [1, 1, 0, 0],
-        [1, 0, 0, 0],
-        [0, 0, 1, 1],
-        [0, 1, 0, 0],
-        [0, 1, 1, 0]
-    ]
+    Y = np.array([
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+        [1, 0, 0],
+        [0, 1, 0]
+    ])
 
-    model = BertClassifier()
-    for epoch in range(5):
-        for x, y in zip(X, Y):
-            model.partial_fit([x], np.array([y]))
+    model = BertClassifier(multilabel=False)
+    model.fit(X, Y)
     Y_pred = model.predict(X)
     Y_prob_pred = model.predict_proba(X)
     assert Y_pred.sum() != 0
-    assert Y_prob_pred.sum() != np.array(Y).size
+    assert Y_pred.sum() != Y.size
     assert Y_prob_pred.max() <= 1
     assert Y_prob_pred.min() >= 0
-    assert Y_pred.shape == np.array(Y).shape
-    assert Y_prob_pred.shape == np.array(Y).shape
+    assert Y_pred.shape == Y.shape
+    assert Y_prob_pred.shape == Y.shape
     assert model.losses[0] > model.losses[-1]
 
 

--- a/wellcomeml/ml/bert_classifier.py
+++ b/wellcomeml/ml/bert_classifier.py
@@ -33,7 +33,7 @@ class BertClassifier(BaseEstimator, TransformerMixin):
     def __init__(self, learning_rate=5e-5, epochs=5, batch_size=8,
                  pretrained="bert-base-uncased", threshold=0.5,
                  validation_split=0.1, max_length=512, multilabel=True,
-                 from_pt=False):
+                 from_pt=False, random_seed=42):
         """
         Args:
            learning_rate(float): learning rate to optimize model, default 5e-5
@@ -55,7 +55,7 @@ class BertClassifier(BaseEstimator, TransformerMixin):
         self.validation_split = validation_split
         self.max_length = max_length
         self.multilabel = multilabel
-        self.random_seed = 42
+        self.random_seed = random_seed
         self.from_pt = from_pt
 
     def _init_model(self, num_labels=2):


### PR DESCRIPTION
Description
---
This PR rewrites BertClassifier using the hugging face transformers library moving away from spacy-transformers. There are a couple of ways we are doing this

- It gives us more flexibility on the features we can use from transformers as spacy-transformers is a wrapper on top that somehow limits what we can do, for example our ability to use all models available.
- Makes it easier to move towards training our own BERT models since a lot of the components can be reused to create a BERT for language modelling
- It decouples slightly from spacy which is generally bad in being backwards compatible, for example upgrading to spacy v3 caused models trained with bert classifier to break even after making the changes necessary to transition

Fixes #33 

Checklist
---

- [x] Added link to Github issue or Trello card
- [x] Added tests
