### PR TITLE
Add flag and warning for when hdbscan not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ $(VIRTUALENV)/.installed:
 	$(VIRTUALENV)/bin/pip3 install -r requirements_test.txt
 	$(VIRTUALENV)/bin/pip3 install -r docs/requirements.txt # Installs requirements to docs
 	$(VIRTUALENV)/bin/pip3 install -e .[deep-learning]
+	$(VIRTUALENV)/bin/pip3 install hdbscan --no-cache-dir --no-binary :all: --no-build-isolation
 	touch $@
 
 .PHONY: update-docs

--- a/wellcomeml/ml/clustering.py
+++ b/wellcomeml/ml/clustering.py
@@ -19,7 +19,8 @@ except ValueError:
     HDBSCAN_INSTALLED = False
     logger.warning(
         "If you want to use hdbscan you need to run"
-        "pip3 install hdbscan --no-cache-dir --no-binary :all: --no-build-isolation"
+        "pip3 install hdbscan --no-cache-dir --no-binary :all: --no-build-isolation "
+        "Read more https://github.com/wellcometrust/WellcomeML/issues/197"
     )
 import umap
 
@@ -96,7 +97,7 @@ class TextClustering(object):
             'optics': OPTICS
         }
         if HDBSCAN_INSTALLED:
-            clustering_dispatcher['hdbscan'] == HDBSCAN
+            clustering_dispatcher['hdbscan'] = HDBSCAN
 
         if clustering in clustering_dispatcher:
             self.clustering_class = clustering_dispatcher[clustering](

--- a/wellcomeml/ml/clustering.py
+++ b/wellcomeml/ml/clustering.py
@@ -2,6 +2,9 @@ from collections import defaultdict
 import logging
 import os
 
+from wellcomeml.ml import vectorizer
+from wellcomeml.logger import logger
+
 import numpy as np
 from sklearn.base import ClusterMixin
 from sklearn.cluster import DBSCAN, OPTICS, KMeans
@@ -9,11 +12,16 @@ from sklearn.manifold import TSNE
 from sklearn.model_selection import GridSearchCV
 from sklearn.metrics import silhouette_score
 from sklearn.pipeline import Pipeline
-#  from hdbscan import HDBSCAN
+try:
+    from hdbscan import HDBSCAN
+    HDBSCAN_INSTALLED = True
+except ValueError:
+    HDBSCAN_INSTALLED = False
+    logger.warning(
+        "If you want to use hdbscan you need to run"
+        "pip3 install hdbscan --no-cache-dir --no-binary :all: --no-build-isolation"
+    )
 import umap
-
-from wellcomeml.ml import vectorizer
-from wellcomeml.logger import logger
 
 CACHE_DIR = os.path.expanduser("~/.cache/wellcomeml")
 
@@ -85,9 +93,10 @@ class TextClustering(object):
         clustering_dispatcher = {
             'dbscan': DBSCAN,
             'kmeans': KMeans,
-            'optics': OPTICS,
-            # 'hdbscan': HDBSCAN
+            'optics': OPTICS
         }
+        if HDBSCAN_INSTALLED:
+            clustering_dispatcher['hdbscan'] == HDBSCAN
 
         if clustering in clustering_dispatcher:
             self.clustering_class = clustering_dispatcher[clustering](


### PR DESCRIPTION
Description
---

Fixes #197 by delegating to the user to install hdbscan if they wish to use it and warning them about it.

It would be good to add tests both for the flag and for hbscan. Possible need to update documentation of README as well.

We could install them for them as we do for sent2vec in the case that they did not do themselves and tried to use it.

Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests
