### PR TITLE
Efficient CNN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.9
+          python-version: 3.7.10
           architecture: x64
       - name: Checkout Master
         uses: actions/checkout@master

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setuptools.setup(
             'tensorflow==2.4.0',
             'torch',
             'transformers==4.3.0',
-            'tokenizers==0.10.1'
+            'tokenizers==0.10.1',
             'tensorflow-addons'
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setuptools.setup(
             'torch',
             'transformers==4.3.0',
             'tokenizers==0.10.1'
+            'tensorflow-addons'
         ]
     },
     tests_require=[

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -18,7 +18,7 @@ def test_vanilla():
 
     model = Pipeline([
         ('vec', KerasVectorizer()),
-        ('clf', CNNClassifier())
+        ('clf', CNNClassifier(batch_size=2))
     ])
     model.fit(X, Y)
     assert model.score(X, Y) > 0.6
@@ -36,7 +36,7 @@ def test_save_load():
     vec = KerasVectorizer()
     X_vec = vec.fit_transform(X)
 
-    model = CNNClassifier()
+    model = CNNClassifier(batch_size=2)
     model.fit(X_vec, Y)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -59,7 +59,10 @@ def test_save_load_attention():
     vec = KerasVectorizer()
     X_vec = vec.fit_transform(X)
 
-    model = CNNClassifier(attention=True)
+    model = CNNClassifier(
+        batch_size=2,
+        attention=True
+    )
     model.fit(X_vec, Y)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -87,7 +90,10 @@ def test_multilabel():
     ])
     model = Pipeline([
         ('vec', KerasVectorizer()),
-        ('clf', CNNClassifier(multilabel=True))
+        ('clf', CNNClassifier(
+            batch_size=2,
+            multilabel=True
+        ))
     ])
     model.fit(X, Y)
     assert model.score(X, Y) > 0.4
@@ -133,6 +139,7 @@ def test_attention():
     model = Pipeline([
         ('vec', KerasVectorizer()),
         ('clf', CNNClassifier(
+                    batch_size=2,
                     attention=True,
                     attention_heads=10))
     ])
@@ -152,12 +159,14 @@ def test_early_stopping():
     model = Pipeline([
         ('vec', KerasVectorizer()),
         ('clf', CNNClassifier(
+                    batch_size=2,
                     early_stopping=True,
                     nb_epochs=10000
         ))
     ])
     # if early_stopping is not working it will take
     # a lot of time to finish running this test
+    # it will also consume the 4MB of logs in travis
     model.fit(X, Y)
     assert model.score(X, Y) > 0.6
 
@@ -173,7 +182,7 @@ def test_predict_proba():
 
     model = Pipeline([
         ('vec', KerasVectorizer()),
-        ('clf', CNNClassifier())
+        ('clf', CNNClassifier(batch_size=2))
     ])
     model.fit(X, Y)
     Y_pred_prob = model.predict_proba(X)
@@ -192,7 +201,10 @@ def test_threshold():
 
     model = Pipeline([
         ('vec', KerasVectorizer()),
-        ('clf', CNNClassifier(threshold=0.1))
+        ('clf', CNNClassifier(
+            batch_size=2,
+            threshold=0.1
+        ))
     ])
     model.fit(X, Y)
     Y_pred_expected = model.predict_proba(X) > 0.1
@@ -211,7 +223,7 @@ def test_XY_list():
 
     model = Pipeline([
         ('vec', KerasVectorizer()),
-        ('clf', CNNClassifier())
+        ('clf', CNNClassifier(batch_size=2))
     ])
     model.fit(X, Y)
     assert model.score(X, Y) > 0.6

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -3,6 +3,7 @@ import tempfile
 from wellcomeml.ml import CNNClassifier, KerasVectorizer
 from sklearn.pipeline import Pipeline
 from scipy.sparse import csr_matrix
+import tensorflow as tf
 import numpy as np
 
 
@@ -197,3 +198,40 @@ def test_threshold():
     Y_pred_expected = model.predict_proba(X) > 0.1
     Y_pred = model.predict(X)
     assert np.array_equal(Y_pred_expected, Y_pred)
+
+
+def test_XY_list():
+    X = [
+        "One",
+        "One only",
+        "Two nothing else",
+        "Two and three"
+    ]
+    Y = [0, 0, 1, 1]
+
+    model = Pipeline([
+        ('vec', KerasVectorizer()),
+        ('clf', CNNClassifier())
+    ])
+    model.fit(X, Y)
+    assert model.score(X, Y) > 0.6
+
+
+def test_XY_dataset():
+    X = [
+        "One",
+        "One only",
+        "Two nothing else",
+        "Two and three"
+    ]
+    Y = np.array([0, 0, 1, 1])
+
+    vec = KerasVectorizer()
+    X_vec = vec.fit_transform(X)
+
+    data = tf.data.Dataset.from_tensor_slices((X_vec, Y))
+    data = data.shuffle(100)
+    clf = CNNClassifier(batch_size=2)
+
+    clf.fit(data)
+    assert clf.score(X_vec, Y) > 0.6

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -209,7 +209,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             Y_max = Y.max()
             X_shape = X.shape[1]
             Y_shape = Y.shape[1] if self.multilabel else Y.shape[0]
-        else:  # tensorflow dataset
+        elif isinstance(X, tf.data.Dataset):
             logger.info(
                 "Initializing sequence_length, vocab_size \
                 and nb_outputs from data. This might take a while."
@@ -230,10 +230,13 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
                 if batch_Y_max > Y_max:
                     Y_max = batch_Y_max
                 if not Y_shape:
-                    Y_shape = Y_batch.shape[1] if self.multilabel else Y.shape[0]
+                    Y_shape = Y_batch.shape[1] if self.multilabel else Y_batch.shape[0]
                 if not X_shape:
                     X_shape = X_batch.shape[1]
                 steps_per_epoch += 1
+        else:
+            logger.error("CNN currently supports X to one of np.ndarray or tf.data.Dataset")
+            raise NotImplementedError
 
         sequence_length = X_shape
         vocab_size = X_max + 1
@@ -268,7 +271,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
                 patience=5, restore_best_weights=True)
             callbacks.append(early_stopping)
 
-        if type(X) is not np.ndarray:  # tensorflow dataset
+        if isinstance(X, tf.data.Dataset):
             self.model.fit(
                 train_data,
                 validation_data=val_data,

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -208,7 +208,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             X_max = X.max()
             Y_max = Y.max()
             X_shape = X.shape[1]
-            Y_shape = Y.shape[1]
+            Y_shape = Y.shape[1] if self.multilabel else Y.shape[0]
         else:  # tensorflow dataset
             logger.info(
                 "Initializing sequence_length, vocab_size \
@@ -230,7 +230,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
                 if batch_Y_max > Y_max:
                     Y_max = batch_Y_max
                 if not Y_shape:
-                    Y_shape = Y_batch.shape[1]
+                    Y_shape = Y_batch.shape[1] if self.multilabel else Y.shape[0]
                 if not X_shape:
                     X_shape = X_batch.shape[1]
                 steps_per_epoch += 1
@@ -320,7 +320,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             Y_pred = vstack(Y_pred)
             return Y_pred
         else:
-            return self.model.predict(X).numpy() > self.threshold
+            return self.model.predict(X) > self.threshold
 
     def predict_proba(self, X):
         # sparse_y not relevant as probs are dense

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -117,7 +117,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             "Initializing sequence_length, vocab_size \
             and nb_outputs from data. This might take a while."
         )
-        if type(X) is np.ndarray:
+        if isinstance(X, np.ndarray):
             X_max = X.max()
             Y_max = Y.max()
             X_shape = X.shape[1]
@@ -262,7 +262,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         if not (self.sequence_length and self.vocab_size and self.nb_outputs and steps_per_epoch):
             steps_per_epoch = self._init_from_data(X, Y)
 
-        if type(X) is np.ndarray:
+        if isinstance(X, np.ndarray):
             data = self._prepare_data(X, Y, shuffle=True)
         else:  # tensorflow dataset
             data = X.batch(self.batch_size)
@@ -306,7 +306,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             X = np.array(X)
 
         def yield_X_batch(X):
-            if type(X) is np.ndarray:
+            if isinstance(X, np.ndarray):
                 for i in range(0, X.shape[0], self.batch_size):
                     X_batch = X[i: i+self.batch_size]
                     yield X_batch

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -271,7 +271,9 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         if train_steps_per_epoch == 0:
             logger.warning(
                 "Not enough data for validation. Consider decreasing \
-                batch_size or validation_split"
+                batch_size or validation_split. Some features that \
+                rely on validation metrics like early stopping might \
+                not work"
             )
         else:
             steps_per_epoch = train_steps_per_epoch

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -197,7 +197,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         ]
         model.compile(optimizer=optimizer, loss="binary_crossentropy", metrics=metrics)
         return model
-    
+
     def fit(self, X, Y=None, embedding_matrix=None):
         if isinstance(X, list):
             X = np.array(X)
@@ -209,8 +209,11 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             Y_max = Y.max()
             X_shape = X.shape[1]
             Y_shape = Y.shape[1]
-        else: # tensorflow dataset
-            logger.info("Initializing sequence_length, vocab_size and nb_outputs from data. This might take a while.")
+        else:  # tensorflow dataset
+            logger.info(
+                "Initializing sequence_length, vocab_size \
+                and nb_outputs from data. This might take a while."
+            )
             X = X.batch(self.batch_size)
 
             # init from iterating over dataset
@@ -235,15 +238,17 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         sequence_length = X_shape
         vocab_size = X_max + 1
         nb_outputs = Y_max if not self.multilabel else Y_shape
-        logger.info(f"Initialized sequence_length: {sequence_length}, vocab_size: {vocab_size}, nb_outputs: {nb_outputs}")
-
+        logger.info(
+            f"Initialized sequence_length: {sequence_length}, \
+            vocab_size: {vocab_size}, nb_outputs: {nb_outputs}"
+        )
         if type(X) is np.ndarray:
             X_train, X_val, Y_train, Y_val = train_test_split(
                 X, Y, test_size=self.validation_split, shuffle=True
             )
             steps_per_epoch = math.ceil(X_train.shape[0] / self.batch_size)
             validation_steps = math.ceil(X_val.shape[0] / self.batch_size)
-        else: # tensorflow dataset
+        else:  # tensorflow dataset
             steps_per_epoch = int((1-self.validation_split) * steps_per_epoch)
             train_data = X.take(steps_per_epoch)
             val_data = X.skip(steps_per_epoch)
@@ -263,7 +268,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
                 patience=5, restore_best_weights=True)
             callbacks.append(early_stopping)
 
-        if type(X) is not np.ndarray: # tensorflow dataset
+        if type(X) is not np.ndarray:  # tensorflow dataset
             self.model.fit(
                 train_data,
                 validation_data=val_data,
@@ -292,19 +297,19 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
                 validation_data=(X_val, Y_val),
                 callbacks=callbacks,
             )
-        
-        
+
         return self
 
     def predict(self, X):
         if isinstance(X, list):
             X = np.array(X)
+
         def yield_X_batch(X):
             if type(X) is np.ndarray:
                 for i in range(0, X.shape[0], self.batch_size):
                     X_batch = X[i: i+self.batch_size]
                     yield X_batch
-            else: # tensorflow dataset
+            else:  # tensorflow dataset
                 yield X.batch(self.batch_size)
 
         if self.sparse_y:
@@ -316,7 +321,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             return Y_pred
         else:
             return self.model.predict(X).numpy() > self.threshold
-    
+
     def predict_proba(self, X):
         # sparse_y not relevant as probs are dense
         return self.model.predict(X, self.batch_size)


### PR DESCRIPTION
Description
---

This PR reduces the memory requirement needed for CNN by introducing the ability to pass a tensorflow dataset as an input. In order to unify how data are handled within CNN, when data passed is a list of numpy array, they are converted to a tensorflow dataset as well.

What makes tensorflow dataset light in memory is their ability to initialise from a generator. Actually passing a generator is another way CNN can become memory light but then functionality around batching, shuffling etc would need to be implemented when they come for free with a tensorflow dataset.

Checklist
---

- [x] Added link to Github issue or Trello card
- [x] Added tests
