### PR TITLE
Fix version to latest version on PyPi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2021.2.1
+
+Bug fixes:
+- Update version to 2021.2.1 which was out of sync in latest release #206
+
 # 2021.2.0
 
 Major changes

--- a/wellcomeml/__version__.py
+++ b/wellcomeml/__version__.py
@@ -1,5 +1,5 @@
 __name__ = "wellcomeml"
-__version__ = "2021.2.0"
+__version__ = "2021.2.1"
 __description__ = """Utilities for managing nlp models and for
                      processing text-related data at Wellcome Data Labs"""
 __url__ = "https://github.com/wellcometrust/wellcomeml/tree/master"

--- a/wellcomeml/__version__.py
+++ b/wellcomeml/__version__.py
@@ -1,5 +1,5 @@
 __name__ = "wellcomeml"
-__version__ = "2021.1.0"
+__version__ = "2021.2.0"
 __description__ = """Utilities for managing nlp models and for
                      processing text-related data at Wellcome Data Labs"""
 __url__ = "https://github.com/wellcometrust/wellcomeml/tree/master"


### PR DESCRIPTION
Description
---

We forgot to update the version internal during the last release. Unfortunately we cannot overwrite the version in PyPi so this just fixes the problem for those cloning and using from Github. Ideally we want to update to `2021.02.1` and upload to PyPi which I am happy to do.

Fixes #206
 
Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests
