### PR TITLE
Fix error caught when hdbscan is missing

### DIFF
--- a/wellcomeml/ml/clustering.py
+++ b/wellcomeml/ml/clustering.py
@@ -15,7 +15,7 @@ from sklearn.pipeline import Pipeline
 try:
     from hdbscan import HDBSCAN
     HDBSCAN_INSTALLED = True
-except ValueError:
+except ModuleNotFoundError:
     HDBSCAN_INSTALLED = False
     logger.warning(
         "If you want to use hdbscan you need to run"

--- a/wellcomeml/ml/clustering.py
+++ b/wellcomeml/ml/clustering.py
@@ -15,7 +15,7 @@ from sklearn.pipeline import Pipeline
 try:
     from hdbscan import HDBSCAN
     HDBSCAN_INSTALLED = True
-except ModuleNotFoundError:
+except (ValueError, ModuleNotFoundError):
     HDBSCAN_INSTALLED = False
     logger.warning(
         "If you want to use hdbscan you need to run"


### PR DESCRIPTION
Description
---

Fixes #217

Essentially we were catching a `ValueError` instead of `ModuleNotFoundError`

Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests
