### PR TITLE
VotingClassifier extras

### DIFF
--- a/examples/voting_classifier_ensemble.py
+++ b/examples/voting_classifier_ensemble.py
@@ -1,4 +1,4 @@
-from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
+from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.linear_model import SGDClassifier
 from sklearn.naive_bayes import MultinomialNB
@@ -59,8 +59,18 @@ Y = [
     [0, 0, 1]
 ]
 
-pipe1 = Pipeline([('count_vect', CountVectorizer()), ('sgd', OneVsRestClassifier(SGDClassifier(loss="log")))])
-pipe2 = Pipeline([('count_vect', CountVectorizer()), ('nb', OneVsRestClassifier(MultinomialNB()))])
+pipe1 = Pipeline(
+    [
+        ('count_vect', CountVectorizer()),
+        ('sgd', OneVsRestClassifier(SGDClassifier(loss="log")))
+    ]
+)
+pipe2 = Pipeline(
+    [
+        ('count_vect', CountVectorizer()),
+        ('nb', OneVsRestClassifier(MultinomialNB()))
+    ]
+)
 
 pipe1.fit(X, Y)
 pipe2.fit(X, Y)
@@ -73,8 +83,18 @@ print(Y_pred)
 
 Y = [1, 0, 1, 0]
 
-pipe1 = Pipeline([('count_vect', CountVectorizer()), ('sgd', SGDClassifier(loss="log"))])
-pipe2 = Pipeline([('count_vect', CountVectorizer()), ('nb', MultinomialNB())])
+pipe1 = Pipeline(
+    [
+        ('count_vect', CountVectorizer()),
+        ('sgd', SGDClassifier(loss="log"))
+    ]
+)
+pipe2 = Pipeline(
+    [
+        ('count_vect', CountVectorizer()),
+        ('nb', MultinomialNB())
+    ]
+)
 
 pipe1.fit(X, Y)
 pipe2.fit(X, Y)

--- a/examples/voting_classifier_ensemble.py
+++ b/examples/voting_classifier_ensemble.py
@@ -1,4 +1,4 @@
-from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.linear_model import SGDClassifier
 from sklearn.naive_bayes import MultinomialNB
@@ -50,3 +50,15 @@ voting_classifier = WellcomeVotingClassifier(
 
 Y_pred = voting_classifier.predict(X_vec)
 print(Y_pred)
+
+count_vect = CountVectorizer()
+count_vect.fit(X)
+tfidf_vect = TfidfVectorizer()
+tfidf_vect.fit(X)
+
+voting_classifier = WellcomeVotingClassifier(
+    estimators=[(nb, count_vect), (nb, tfidf_vect)], voting="soft"
+)
+Y_pred = voting_classifier.predict(X)
+print(Y_pred)
+

--- a/examples/voting_classifier_ensemble.py
+++ b/examples/voting_classifier_ensemble.py
@@ -2,6 +2,7 @@ from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.linear_model import SGDClassifier
 from sklearn.naive_bayes import MultinomialNB
+from sklearn.pipeline import Pipeline
 
 from wellcomeml.ml.voting_classifier import WellcomeVotingClassifier
 
@@ -51,13 +52,36 @@ voting_classifier = WellcomeVotingClassifier(
 Y_pred = voting_classifier.predict(X_vec)
 print(Y_pred)
 
-count_vect = CountVectorizer()
-count_vect.fit(X)
-tfidf_vect = TfidfVectorizer()
-tfidf_vect.fit(X)
+Y = [
+    [1, 1, 0],
+    [1, 0, 0],
+    [0, 1, 1],
+    [0, 0, 1]
+]
+
+pipe1 = Pipeline([('count_vect', CountVectorizer()), ('sgd', OneVsRestClassifier(SGDClassifier(loss="log")))])
+pipe2 = Pipeline([('count_vect', CountVectorizer()), ('nb', OneVsRestClassifier(MultinomialNB()))])
+
+pipe1.fit(X, Y)
+pipe2.fit(X, Y)
 
 voting_classifier = WellcomeVotingClassifier(
-    estimators=[(nb, count_vect), (nb, tfidf_vect)], voting="soft"
+    estimators=[pipe1, pipe2], voting="soft", multilabel=True
 )
 Y_pred = voting_classifier.predict(X)
+print(Y_pred)
+
+Y = [1, 0, 1, 0]
+
+pipe1 = Pipeline([('count_vect', CountVectorizer()), ('sgd', SGDClassifier(loss="log"))])
+pipe2 = Pipeline([('count_vect', CountVectorizer()), ('nb', MultinomialNB())])
+
+pipe1.fit(X, Y)
+pipe2.fit(X, Y)
+
+voting_classifier = WellcomeVotingClassifier(
+    estimators=[sgd, nb], voting="soft"
+)
+
+Y_pred = voting_classifier.predict(X_vec)
 print(Y_pred)

--- a/examples/voting_classifier_ensemble.py
+++ b/examples/voting_classifier_ensemble.py
@@ -61,4 +61,3 @@ voting_classifier = WellcomeVotingClassifier(
 )
 Y_pred = voting_classifier.predict(X)
 print(Y_pred)
-

--- a/tests/test_voting_classifier.py
+++ b/tests/test_voting_classifier.py
@@ -31,9 +31,10 @@ class MockEstimator():
 class MockVectorizer():
     def __init__(self, size):
         self.size = size
-        
+
     def transform(self, X):
         return np.random.rand(len(X), self.size)
+
 
 def test_multilabel():
     Y1_prob = np.array([
@@ -258,4 +259,3 @@ def test_binary_hard_num_agree():
     X = ["mock", "data", "not used"]
     Y = voting_classifier.predict(X)
     assert np.array_equal(Y, Y_expected)
-

--- a/tests/test_voting_classifier.py
+++ b/tests/test_voting_classifier.py
@@ -153,37 +153,76 @@ def test_hard_voting():
     Y = voting_classifier.predict(X)
     assert np.array_equal(Y, Y_expected)
 
-
-def test_inc_vectorizer():
-
+def test_multilabel_hard():
+    # Since no num_agree, majority (>=2/3) agreement needed
     Y1_prob = np.array([
-        [0.9, 0.1],
-        [0.2, 0.8],
-        [0.3, 0.7]
+        [0.9, 0.9],
+        [0.1, 0.9],
+        [0.1, 0.9]
     ])
     Y2_prob = np.array([
-        [0.7, 0.3],
+        [0.9, 0.9],
+        [0.9, 0.9],
+        [0.1, 0.1]
+    ])
+    Y3_prob = np.array([
+        [0.9, 0.9],
         [0.9, 0.1],
-        [0.4, 0.6]
+        [0.1, 0.1]
     ])
     Y_expected = np.array([
-        0,
-        0,
-        1
+        [1, 1],
+        [1, 1],
+        [0, 0]
     ])
-
-    pipe1 = Pipeline([('vect', MockVectorizer(size=3)), ('est', MockEstimator(Y1_prob))])
-    pipe2 = Pipeline([('vect', MockVectorizer(size=5)), ('est', MockEstimator(Y2_prob))])
+    est1 = MockEstimator(Y1_prob, multilabel=True)
+    est2 = MockEstimator(Y2_prob, multilabel=True)
+    est3 = MockEstimator(Y3_prob, multilabel=True)
 
     voting_classifier = WellcomeVotingClassifier(
-        estimators=[pipe1, pipe2], voting="soft"
+        estimators=[est1, est2, est3], voting="hard", multilabel=True
     )
     X = ["mock", "data", "not used"]
     Y = voting_classifier.predict(X)
     assert np.array_equal(Y, Y_expected)
 
+def test_multilabel_hard_num_agree():
+    # >=3/3 agreement needed
+    Y1_prob = np.array([
+        [0.9, 0.9],
+        [0.1, 0.9],
+        [0.1, 0.9]
+    ])
+    Y2_prob = np.array([
+        [0.9, 0.9],
+        [0.9, 0.9],
+        [0.1, 0.1]
+    ])
+    Y3_prob = np.array([
+        [0.9, 0.9],
+        [0.9, 0.1],
+        [0.1, 0.1]
+    ])
+    Y_expected = np.array([
+        [1, 1],
+        [0, 0],
+        [0, 0]
+    ])
+    est1 = MockEstimator(Y1_prob, multilabel=True)
+    est2 = MockEstimator(Y2_prob, multilabel=True)
+    est3 = MockEstimator(Y3_prob, multilabel=True)
 
-def test_binary_hard_majority():
+    voting_classifier = WellcomeVotingClassifier(
+        estimators=[est1, est2, est3],
+        voting="hard",
+        multilabel=True,
+        num_agree=3
+    )
+    X = ["mock", "data", "not used"]
+    Y = voting_classifier.predict(X)
+    assert np.array_equal(Y, Y_expected)
+
+def test_binary_hard():
 
     Y1_prob = np.array([
         [0.9, 0.1],
@@ -247,7 +286,7 @@ def test_binary_hard_num_agree():
     ])
     Y_expected = np.array([
         0,
-        1,
+        0,
         1
     ])
     est1 = MockEstimator(Y1_prob)
@@ -257,6 +296,111 @@ def test_binary_hard_num_agree():
 
     voting_classifier = WellcomeVotingClassifier(
         estimators=[est1, est2, est3, est4], voting="hard", num_agree=2
+    )
+    X = ["mock", "data", "not used"]
+    Y = voting_classifier.predict(X)
+    assert np.array_equal(Y, Y_expected)
+
+def test_multiclass_hard():
+
+    Y1_prob = np.array([
+        [0.6, 0.1, 0.1, 0.2],
+        [0.2, 0.3, 0.1, 0.4],
+        [0.3, 0.1, 0.4, 0.2]
+    ])
+    Y2_prob = np.array([
+        [0.5, 0.3, 0.2, 0.0],
+        [0.1, 0.6, 0.1, 0.2],
+        [0.1, 0.3, 0.1, 0.5]
+    ])
+    Y3_prob = np.array([
+        [0.5, 0.3, 0.2, 0.0],
+        [0.2, 0.3, 0.1, 0.4],
+        [0.1, 0.5, 0.1, 0.3]
+    ])
+    # Using highest values:
+    # 1st data point: 0: 3 votes -> clear winner is 0
+    # 2nd data point: 1: 1 vote, 3: 2 votes -> clear winner (in majority voting) is 3
+    # 3rd data point: 2: 1 vote, 3: 1 vote, 1: 1 vote -> no winner, pick first in numerical order, so 1
+    Y_expected = np.array([
+        0,
+        3,
+        1
+    ])
+    est1 = MockEstimator(Y1_prob)
+    est2 = MockEstimator(Y2_prob)
+    est3 = MockEstimator(Y3_prob)
+
+    voting_classifier = WellcomeVotingClassifier(
+        estimators=[est1, est2, est3], voting="hard"
+    )
+    X = ["mock", "data", "not used"]
+    Y = voting_classifier.predict(X)
+
+    assert np.array_equal(Y, Y_expected)
+
+def test_multiclass_hard_num_agree():
+
+    Y1_prob = np.array([
+        [0.6, 0.1, 0.1, 0.2],
+        [0.2, 0.3, 0.1, 0.4],
+        [0.3, 0.1, 0.4, 0.2]
+    ])
+    Y2_prob = np.array([
+        [0.5, 0.3, 0.2, 0.0],
+        [0.1, 0.6, 0.1, 0.2],
+        [0.1, 0.3, 0.1, 0.5]
+    ])
+    Y3_prob = np.array([
+        [0.5, 0.3, 0.2, 0.0],
+        [0.2, 0.3, 0.1, 0.4],
+        [0.1, 0.5, 0.1, 0.3]
+    ])
+    # Using highest values:
+    # 1st data point: 0: 3 votes -> clear winner is 0
+    # 2nd data point: 1: 1 vote, 3: 2 votes -> no winner, pick first in numerical order, so 1
+    # 3rd data point: 2: 1 vote, 3: 1 vote, 1: 1 vote -> no winner, pick first in numerical order, so 1
+    Y_expected = np.array([
+        0,
+        1,
+        1
+    ])
+    est1 = MockEstimator(Y1_prob)
+    est2 = MockEstimator(Y2_prob)
+    est3 = MockEstimator(Y3_prob)
+
+    voting_classifier = WellcomeVotingClassifier(
+        estimators=[est1, est2, est3],
+        voting="hard",
+        num_agree=3
+    )
+    X = ["mock", "data", "not used"]
+    Y = voting_classifier.predict(X)
+    assert np.array_equal(Y, Y_expected)
+
+def test_inc_vectorizer():
+
+    Y1_prob = np.array([
+        [0.9, 0.1],
+        [0.2, 0.8],
+        [0.3, 0.7]
+    ])
+    Y2_prob = np.array([
+        [0.7, 0.3],
+        [0.9, 0.1],
+        [0.4, 0.6]
+    ])
+    Y_expected = np.array([
+        0,
+        0,
+        1
+    ])
+
+    pipe1 = Pipeline([('vect', MockVectorizer(size=3)), ('est', MockEstimator(Y1_prob))])
+    pipe2 = Pipeline([('vect', MockVectorizer(size=5)), ('est', MockEstimator(Y2_prob))])
+
+    voting_classifier = WellcomeVotingClassifier(
+        estimators=[pipe1, pipe2], voting="soft"
     )
     X = ["mock", "data", "not used"]
     Y = voting_classifier.predict(X)

--- a/tests/test_voting_classifier.py
+++ b/tests/test_voting_classifier.py
@@ -28,6 +28,13 @@ class MockEstimator():
         return self.Y_prob
 
 
+class MockVectorizer():
+    def __init__(self, size):
+        self.size = size
+        
+    def transform(self, X):
+        return np.random.rand(len(X), self.size)
+
 def test_multilabel():
     Y1_prob = np.array([
         [0.9, 0.5],
@@ -140,3 +147,36 @@ def test_hard_voting():
     X = ["mock", "data", "not used"]
     Y = voting_classifier.predict(X)
     assert np.array_equal(Y, Y_expected)
+
+
+def test_inc_vectorizer():
+
+    Y1_prob = np.array([
+        [0.9, 0.1],
+        [0.2, 0.8],
+        [0.3, 0.7]
+    ])
+    Y2_prob = np.array([
+        [0.7, 0.3],
+        [0.9, 0.1],
+        [0.4, 0.6]
+    ])
+    Y_expected = np.array([
+        0,
+        0,
+        1
+    ])
+    est1 = MockEstimator(Y1_prob)
+    est2 = MockEstimator(Y2_prob)
+
+    vect1 = MockVectorizer(size=3)
+    vect2 = MockVectorizer(size=5)
+
+    voting_classifier = WellcomeVotingClassifier(
+        estimators=[(est1, vect1), (est2, vect2)], voting="soft"
+    )
+    X = ["mock", "data", "not used"]
+    Y = voting_classifier.predict(X)
+    assert np.array_equal(Y, Y_expected)
+
+

--- a/tests/test_voting_classifier.py
+++ b/tests/test_voting_classifier.py
@@ -120,8 +120,7 @@ def test_multiclass():
     Y = voting_classifier.predict(X)
     assert np.array_equal(Y, Y_expected)
 
-
-def test_hard_voting():
+def test_binary_hard_odd():
     Y1_prob = np.array([
         [0.9, 0.1],
         [0.2, 0.8],
@@ -148,6 +147,45 @@ def test_hard_voting():
 
     voting_classifier = WellcomeVotingClassifier(
         estimators=[est1, est2, est3]
+    )
+    X = ["mock", "data", "not used"]
+    Y = voting_classifier.predict(X)
+    assert np.array_equal(Y, Y_expected)
+
+def test_binary_hard_even():
+
+    Y1_prob = np.array([
+        [0.9, 0.1],
+        [0.9, 0.1],
+        [0.9, 0.1]
+    ])
+    Y2_prob = np.array([
+        [0.8, 0.2],
+        [0.8, 0.2],
+        [0.2, 0.8]
+    ])
+    Y3_prob = np.array([
+        [0.7, 0.3],
+        [0.3, 0.7],
+        [0.3, 0.7]
+    ])
+    Y4_prob = np.array([
+        [0.4, 0.6],
+        [0.4, 0.6],
+        [0.4, 0.6]
+    ])
+    Y_expected = np.array([
+        0,
+        0,
+        1
+    ])
+    est1 = MockEstimator(Y1_prob)
+    est2 = MockEstimator(Y2_prob)
+    est3 = MockEstimator(Y3_prob)
+    est4 = MockEstimator(Y4_prob)
+
+    voting_classifier = WellcomeVotingClassifier(
+        estimators=[est1, est2, est3, est4], voting="hard"
     )
     X = ["mock", "data", "not used"]
     Y = voting_classifier.predict(X)
@@ -217,45 +255,6 @@ def test_multilabel_hard_num_agree():
         voting="hard",
         multilabel=True,
         num_agree=3
-    )
-    X = ["mock", "data", "not used"]
-    Y = voting_classifier.predict(X)
-    assert np.array_equal(Y, Y_expected)
-
-def test_binary_hard():
-
-    Y1_prob = np.array([
-        [0.9, 0.1],
-        [0.9, 0.1],
-        [0.9, 0.1]
-    ])
-    Y2_prob = np.array([
-        [0.8, 0.2],
-        [0.8, 0.2],
-        [0.2, 0.8]
-    ])
-    Y3_prob = np.array([
-        [0.7, 0.3],
-        [0.3, 0.7],
-        [0.3, 0.7]
-    ])
-    Y4_prob = np.array([
-        [0.4, 0.6],
-        [0.4, 0.6],
-        [0.4, 0.6]
-    ])
-    Y_expected = np.array([
-        0,
-        0,
-        1
-    ])
-    est1 = MockEstimator(Y1_prob)
-    est2 = MockEstimator(Y2_prob)
-    est3 = MockEstimator(Y3_prob)
-    est4 = MockEstimator(Y4_prob)
-
-    voting_classifier = WellcomeVotingClassifier(
-        estimators=[est1, est2, est3, est4], voting="hard"
     )
     X = ["mock", "data", "not used"]
     Y = voting_classifier.predict(X)

--- a/tests/test_voting_classifier.py
+++ b/tests/test_voting_classifier.py
@@ -180,3 +180,82 @@ def test_inc_vectorizer():
     assert np.array_equal(Y, Y_expected)
 
 
+def test_binary_hard_majority():
+
+    Y1_prob = np.array([
+        [0.9, 0.1],
+        [0.9, 0.1],
+        [0.9, 0.1]
+    ])
+    Y2_prob = np.array([
+        [0.8, 0.2],
+        [0.8, 0.2],
+        [0.2, 0.8]
+    ])
+    Y3_prob = np.array([
+        [0.7, 0.3],
+        [0.3, 0.7],
+        [0.3, 0.7]
+    ])
+    Y4_prob = np.array([
+        [0.4, 0.6],
+        [0.4, 0.6],
+        [0.4, 0.6]
+    ])
+    Y_expected = np.array([
+        0,
+        0,
+        1
+    ])
+    est1 = MockEstimator(Y1_prob)
+    est2 = MockEstimator(Y2_prob)
+    est3 = MockEstimator(Y3_prob)
+    est4 = MockEstimator(Y4_prob)
+
+    voting_classifier = WellcomeVotingClassifier(
+        estimators=[est1, est2, est3, est4], voting="hard"
+    )
+    X = ["mock", "data", "not used"]
+    Y = voting_classifier.predict(X)
+    assert np.array_equal(Y, Y_expected)
+
+
+def test_binary_hard_num_agree():
+
+    Y1_prob = np.array([
+        [0.9, 0.1],
+        [0.9, 0.1],
+        [0.9, 0.1]
+    ])
+    Y2_prob = np.array([
+        [0.8, 0.2],
+        [0.8, 0.2],
+        [0.2, 0.8]
+    ])
+    Y3_prob = np.array([
+        [0.7, 0.3],
+        [0.3, 0.7],
+        [0.3, 0.7]
+    ])
+    Y4_prob = np.array([
+        [0.4, 0.6],
+        [0.4, 0.6],
+        [0.4, 0.6]
+    ])
+    Y_expected = np.array([
+        0,
+        1,
+        1
+    ])
+    est1 = MockEstimator(Y1_prob)
+    est2 = MockEstimator(Y2_prob)
+    est3 = MockEstimator(Y3_prob)
+    est4 = MockEstimator(Y4_prob)
+
+    voting_classifier = WellcomeVotingClassifier(
+        estimators=[est1, est2, est3, est4], voting="hard", num_agree=2
+    )
+    X = ["mock", "data", "not used"]
+    Y = voting_classifier.predict(X)
+    assert np.array_equal(Y, Y_expected)
+

--- a/tests/test_voting_classifier.py
+++ b/tests/test_voting_classifier.py
@@ -1,4 +1,5 @@
 import numpy as np
+from sklearn.pipeline import Pipeline
 
 from wellcomeml.ml import WellcomeVotingClassifier
 
@@ -31,6 +32,9 @@ class MockEstimator():
 class MockVectorizer():
     def __init__(self, size):
         self.size = size
+
+    def fit(self, X):
+        pass
 
     def transform(self, X):
         return np.random.rand(len(X), self.size)
@@ -167,14 +171,12 @@ def test_inc_vectorizer():
         0,
         1
     ])
-    est1 = MockEstimator(Y1_prob)
-    est2 = MockEstimator(Y2_prob)
 
-    vect1 = MockVectorizer(size=3)
-    vect2 = MockVectorizer(size=5)
+    pipe1 = Pipeline([('vect', MockVectorizer(size=3)), ('est', MockEstimator(Y1_prob))])
+    pipe2 = Pipeline([('vect', MockVectorizer(size=5)), ('est', MockEstimator(Y2_prob))])
 
     voting_classifier = WellcomeVotingClassifier(
-        estimators=[(est1, vect1), (est2, vect2)], voting="soft"
+        estimators=[pipe1, pipe2], voting="soft"
     )
     X = ["mock", "data", "not used"]
     Y = voting_classifier.predict(X)

--- a/wellcomeml/ml/voting_classifier.py
+++ b/wellcomeml/ml/voting_classifier.py
@@ -11,14 +11,15 @@ import numpy as np
 
 
 class WellcomeVotingClassifier(VotingClassifier):
-    def __init__(self, multilabel=False, *args, **kwargs):
+    def __init__(self, multilabel=False, num_agree=None, *args, **kwargs):
         super(WellcomeVotingClassifier, self).__init__(*args, **kwargs)
         self.pretrained = self._is_pretrained()
         self.multilabel = multilabel
+        self.num_agree = num_agree
 
     def _is_pretrained(self):
         try:
-            check_is_fitted(self, 'estimators')
+            check_is_fitted(self, "estimators")
         except NotFittedError:
             return False
         return True
@@ -37,14 +38,19 @@ class WellcomeVotingClassifier(VotingClassifier):
 
     def predict(self, X):
         if self.pretrained:
-            check_is_fitted(self, 'estimators')
+            check_is_fitted(self, "estimators")
 
             estimators = self._get_estimators()
             has_vectorizers = self._check_vectorizer(estimators)
-            
+
             if self.voting == "soft":
                 if has_vectorizers:
-                    Y_probs = np.array([est.predict_proba(vect.transform(X)) for est, vect in estimators])
+                    Y_probs = np.array(
+                        [
+                            est.predict_proba(vect.transform(X))
+                            for est, vect in estimators
+                        ]
+                    )
                 else:
                     Y_probs = np.array([est.predict_proba(X) for est in estimators])
                 Y_prob = np.mean(Y_probs, axis=0)
@@ -53,19 +59,30 @@ class WellcomeVotingClassifier(VotingClassifier):
                 else:
                     return np.argmax(Y_prob, axis=1)
             else:  # hard voting
+
                 if has_vectorizers:
-                    Y_preds = [est.predict(vect.transform(X)) for est, vect in estimators]
+                    Y_preds = [
+                        est.predict(vect.transform(X)) for est, vect in estimators
+                    ]
                 else:
                     Y_preds = [est.predict(X) for est in estimators]
+                Y_preds = np.array(Y_preds)
                 if self.multilabel:
-                    Y_preds = np.array(Y_preds)
-                    axis = 0
+                    return np.apply_along_axis(
+                        lambda x: np.argmax(np.bincount(x)), axis=0, arr=Y_preds
+                    )
                 else:
-                    Y_preds = np.column_stack(Y_preds)
-                    axis = 1
-                return np.apply_along_axis(
-                    lambda x: np.argmax(np.bincount(x)),
-                    axis=axis,
-                    arr=Y_preds)
+                    # If num_agree isn't set then use majority vote
+                    # TO DO: a message when if num_agree is specified, but
+                    # voting=soft and/or multilabel=True then num_agree isn't used
+                    # 'num_agree specified but not used - only used in binary hard voting cases'
+                    if not self.num_agree:
+                        # So if 4 estimators, >= 3 need to agree
+                        self.num_agree = np.ceil((len(estimators) + 1) / 2)
+
+                    return np.apply_along_axis(
+                        lambda x: int(np.sum(x) >= self.num_agree), axis=0, arr=Y_preds
+                    )
+
         else:
             return super(WellcomeVotingClassifier, self).predict(X)

--- a/wellcomeml/ml/voting_classifier.py
+++ b/wellcomeml/ml/voting_classifier.py
@@ -9,6 +9,8 @@ from sklearn.ensemble import VotingClassifier
 from sklearn.exceptions import NotFittedError
 import numpy as np
 
+from wellcomeml.logger import logger
+
 
 class WellcomeVotingClassifier(VotingClassifier):
     def __init__(self, multilabel=False, num_agree=None, *args, **kwargs):
@@ -30,29 +32,16 @@ class WellcomeVotingClassifier(VotingClassifier):
         else:  # tuple with named estimators
             return [est for _, est in self.estimators]
 
-    def _check_vectorizer(self, estimators):
-        if type(estimators[0]) == tuple:
-            return True
-        else:
-            return False
-
     def predict(self, X):
         if self.pretrained:
             check_is_fitted(self, "estimators")
 
             estimators = self._get_estimators()
-            has_vectorizers = self._check_vectorizer(estimators)
 
             if self.voting == "soft":
-                if has_vectorizers:
-                    Y_probs = np.array(
-                        [
-                            est.predict_proba(vect.transform(X))
-                            for est, vect in estimators
-                        ]
-                    )
-                else:
-                    Y_probs = np.array([est.predict_proba(X) for est in estimators])
+                if self.num_agree:
+                    logger.warning("num_agree specified but not needed for soft voting")
+                Y_probs = np.array([est.predict_proba(X) for est in estimators])
                 Y_prob = np.mean(Y_probs, axis=0)
                 if self.multilabel:
                     return np.array(Y_prob > 0.5, dtype=int)
@@ -60,22 +49,16 @@ class WellcomeVotingClassifier(VotingClassifier):
                     return np.argmax(Y_prob, axis=1)
             else:  # hard voting
 
-                if has_vectorizers:
-                    Y_preds = [
-                        est.predict(vect.transform(X)) for est, vect in estimators
-                    ]
-                else:
-                    Y_preds = [est.predict(X) for est in estimators]
+                Y_preds = [est.predict(X) for est in estimators]
                 Y_preds = np.array(Y_preds)
                 if self.multilabel:
+                    if self.num_agree:
+                        logger.warning("num_agree specified but not needed for multilabel voting")
                     return np.apply_along_axis(
                         lambda x: np.argmax(np.bincount(x)), axis=0, arr=Y_preds
                     )
                 else:
                     # If num_agree isn't set then use majority vote
-                    # TO DO: a message when if num_agree is specified, but
-                    # voting=soft and/or multilabel=True then num_agree isn't used
-                    # 'num_agree specified but not used - only used in binary hard voting cases'
                     if not self.num_agree:
                         # So if 4 estimators, >= 3 need to agree
                         self.num_agree = np.ceil((len(estimators) + 1) / 2)

--- a/wellcomeml/ml/voting_classifier.py
+++ b/wellcomeml/ml/voting_classifier.py
@@ -3,7 +3,35 @@ Voting classifier with ability to accept pretrained estimators
 and return results for multilabel Y
 
 Some of the code is taken from https://gist.github.com/tomquisel/a421235422fdf6b51ec2ccc5e3dee1b4
+
+voting = "soft":
+    multilabel = True:
+        The predicted classes will be any classes where the mean probability from all the 
+        estimators is > 0.5.
+    multilabel = False:
+        The predicted class will be class with the largest mean probability from all the 
+        estimators.
+
+voting = "hard":
+    The predicted class(es) will be any class(es) where the majority (or >= num_agree) of 
+    estimators agree. Majority in even cases is 2/2 or >=3/4 (i.e. not 2/4).
+
+    If there are multiple classes with the majority (a tie) then the first one in 
+    numerical order will be chosen.
+
+    In the multiclass case, if there are multiple classes with >= num_agree, then the
+    predicted class will be the first class in a numerically sorted list of the tying classes.
+    e.g.
+        If there is 1 vote for class 0, 2 votes for class 1 and 2 votes for class 2, 
+        then class 1 will be predicted.
+
+    In the binary case, if there is a tie then class 0 is predicted.
+    e.g. 
+        If there are 2 votes for class 0 and 2 votes for class 1, then class 0
+         will be predicted.
+    
 """
+
 from sklearn.utils.validation import check_is_fitted
 from sklearn.ensemble import VotingClassifier
 from sklearn.exceptions import NotFittedError
@@ -40,7 +68,7 @@ class WellcomeVotingClassifier(VotingClassifier):
 
             if self.voting == "soft":
                 if self.num_agree:
-                    logger.warning("num_agree specified but not needed for soft voting")
+                    logger.warning("num_agree specified but not used in soft voting")
                 Y_probs = np.array([est.predict_proba(X) for est in estimators])
                 Y_prob = np.mean(Y_probs, axis=0)
                 if self.multilabel:
@@ -49,23 +77,22 @@ class WellcomeVotingClassifier(VotingClassifier):
                     return np.argmax(Y_prob, axis=1)
             else:  # hard voting
 
+                # If num_agree isn't set then use majority vote
+                if not self.num_agree:
+                    # So if 4 estimators, >= 3 need to agree
+                    self.num_agree = np.ceil((len(estimators) + 1) / 2)
+
                 Y_preds = [est.predict(X) for est in estimators]
                 Y_preds = np.array(Y_preds)
                 if self.multilabel:
-                    if self.num_agree:
-                        logger.warning("num_agree specified but not needed for multilabel voting")
-                    return np.apply_along_axis(
-                        lambda x: np.argmax(np.bincount(x)), axis=0, arr=Y_preds
-                    )
+                    return np.array(Y_preds.sum(axis=0) >= self.num_agree, dtype='int32')
                 else:
-                    # If num_agree isn't set then use majority vote
-                    if not self.num_agree:
-                        # So if 4 estimators, >= 3 need to agree
-                        self.num_agree = np.ceil((len(estimators) + 1) / 2)
-
-                    return np.apply_along_axis(
-                        lambda x: int(np.sum(x) >= self.num_agree), axis=0, arr=Y_preds
-                    )
+                    votes = np.apply_along_axis(lambda x: max(np.bincount(x)), axis=0, arr=Y_preds)
+                    max_class = np.apply_along_axis(lambda x: np.argmax(np.bincount(x)), axis=0, arr=Y_preds)
+                    # If no maximum over the threshold, then pick the first from an ordered list
+                    # of the other options, e.g. if 5,2,3 were voted on pick 2 (not 0)
+                    options = np.sort(np.transpose(Y_preds))
+                    return [m if v >= self.num_agree else options[i][0] for i, (m,v) in enumerate(zip(max_class, votes))]
 
         else:
             return super(WellcomeVotingClassifier, self).predict(X)


### PR DESCRIPTION
Description
---
https://trello.com/c/QiOxLF9l/1195-additions-to-wellcomevotingclassifier

- Add ability to input list of tuples to voting classifier - the estimator and a vectoriser
- In the binary + hard case, you can specify a num_agree parameter to custom how many number of models need to agree in order for final score to be included. before: >50% models agree, custom: >=x models agree. if left unspecified this will default to majority rule (same as before), where if there are 3 models, >=2 need to agree, and if there are 4 models >=3 need to agree.

- New tests for different scenarios

- docstring explaining the nuances

Checklist
---

- [x] Added link to Github issue or Trello card
- [x] Added tests
