### PR TITLE
Add debug stack trace in wellcome/ml.__init__

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,8 @@ rustup-init
 
 Examples can be found in the subfolder `examples`.
 
+## 4. Troubleshooting
+
+If you experience a problem with installing or using WellcomeML please open an issue. It might be
+worth setting the logging level to DEBUG `export LOGGING_LEVEL=DEBUG` which will often expose
+more information that might be informative to resolve the issue.

--- a/wellcomeml/ml/__init__.py
+++ b/wellcomeml/ml/__init__.py
@@ -1,3 +1,4 @@
+import traceback
 from wellcomeml.logger import logger
 
 
@@ -33,3 +34,4 @@ try:
 except ImportError as e:
     logger.error(e)
     logger.warning("Using WellcomeML without extras (transformers & torch).")
+    logger.debug(traceback.format_exc())


### PR DESCRIPTION
Description
---

Fixes #261

Now when you set `export LOGGING_LEVEL=DEBUG` you can get something like
```
2021-03-25 12:00:07 tensorflow DEBUG: Falling back to TensorFlow client; we recommended you install the Cloud TPU client directly with pip install cloud-tpu-client.
2021-03-25 12:00:12 wellcomeml.logger ERROR: No module named 'torch'
2021-03-25 12:00:12 wellcomeml.logger WARNING: Using WellcomeML without extras (transformers & torch).
2021-03-25 12:00:12 wellcomeml.logger DEBUG: Traceback (most recent call last):
  File "/Users/nsorros/code/WellcomeML/wellcomeml/ml/__init__.py", line 12, in <module>
    from .vectorizer import Vectorizer
  File "/Users/nsorros/code/WellcomeML/wellcomeml/ml/vectorizer.py", line 11, in <module>
  1 Description
    from wellcomeml.ml.bert_vectorizer import BertVectorizer
  File "/Users/nsorros/code/WellcomeML/wellcomeml/ml/bert_vectorizer.py", line 9, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```

Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests
