### PR TITLE
Enable tagger which is necessary on V3

### DIFF
--- a/wellcomeml/ml/frequency_vectorizer.py
+++ b/wellcomeml/ml/frequency_vectorizer.py
@@ -97,8 +97,9 @@ class WellcomeTfidf(TfidfVectorizer):
 
             imp.reload(pkg_resources)
             nlp = spacy.load(
-                "en_core_web_sm", disable=["ner", "tagger", "parser", "textcat"]
+                "en_core_web_sm", disable=["ner", "parser", "textcat"]  # Spacy 3.0 needs the tagger to lemmatise
             )
+
 
         logger.info("Using spacy pre-trained lemmatiser.")
         if remove_stopwords_and_punct:


### PR DESCRIPTION
Description
---

Fixed #268 .

As of Spacy v3 the lemmatiser needs the tagger!! We were disabling it from the pipeline which made it stop working and gave warnings:
```
[W108] The rule-based lemmatizer did not find POS annotation for the token 'TEs'. Check that your pipeline includes components that assign token.pos, typically 'tagger'+'attribute_ruler' or 'morphologizer'.
2021-03-31 11:04:08 spacy WARNING: [W108] The rule-based lemmatizer did not find POS annotation for the token 'TEs'. Check that your pipeline includes components that assign token.pos, typically 'tagger'+'attribute_ruler' or 'morphologizer'.
```
This fixes it

Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests
