### PR TITLE
Spacy lemmatizer to use blank model

### DIFF
--- a/wellcomeml/ml/frequency_vectorizer.py
+++ b/wellcomeml/ml/frequency_vectorizer.py
@@ -83,23 +83,9 @@ class WellcomeTfidf(TfidfVectorizer):
 
         """
 
-        try:
-            nlp = spacy.load(
-                "en_core_web_sm", disable=["ner", "tagger", "parser", "textcat"]
-            )
-        except IOError:
-            from wellcomeml.__main__ import download
-
-            download("models")
-            # pkg_resources need to be reloaded to pick up the newly installed models
-            import pkg_resources
-            import imp
-
-            imp.reload(pkg_resources)
-            nlp = spacy.load(
-                "en_core_web_sm", disable=["ner", "parser", "textcat"]  # Spacy 3.0 needs the tagger to lemmatise
-            )
-
+        nlp = spacy.blank("en")
+        nlp.add_pipe("lemmatizer", config={"mode": "lookup"})
+        nlp.initialize()
 
         logger.info("Using spacy pre-trained lemmatiser.")
         if remove_stopwords_and_punct:


### PR DESCRIPTION
Description
---

Fixes https://github.com/wellcometrust/WellcomeML/issues/271 by using blank spacy model.
Running on 1000 grant description: the previous method took 33 secs (when tagger is disabled) and 14 secs (when tagger is not disabled). This new method takes 2 secs.

I also noticed some unusual performance where other methods don't seem to actually lemmatize the text.
```
X = ['the cats sat on the sitting room floors enjoying the sun']
```
**Original method (when the model is already downloaded)**
```
nlp = spacy.load("en_core_web_sm", disable=["ner", "tagger", "parser", "textcat"])
output= [[token.lemma_.lower() for token in doc] for doc in nlp.pipe(X)]
```
gives loads of warning for every token of the form "spacy WARNING: [W108] The rule-based lemmatizer did not find POS annotation for the token 'sun'. Check that your pipeline includes components that assign token.pos, typically 'tagger'+'attribute_ruler' or 'morphologizer'" (allenai seem to have had a [similar issue](https://github.com/allenai/allennlp/issues/5036) with it)
and the output is:
```
[['the', 'cats', 'sat', 'on', 'the', 'sitting', 'room', 'floors', 'enjoying', 'the', 'sun']]
```
I realise this had a bug in it where the tagger shouldn't have been disabled, i.e.
```
nlp = spacy.load("en_core_web_sm", disable=["ner", "parser", "textcat"])
output= [[token.lemma_.lower() for token in doc] for doc in nlp.pipe(X)]
```
does seem to lemmatize correctly.

**I also tried the following method:**
```
from spacy.lang.en import English
from spacy.pipeline.lemmatizer import Lemmatizer
nlp = English()
lemmatizer = Lemmatizer(nlp, model=None,  mode= "lookup")
output= [[lemmatizer.lookup_lemmatize(token)[0].lower() for token in doc] for doc in nlp.pipe(X)]
```
which also gave:
```
[['the', 'cats', 'sat', 'on', 'the', 'sitting', 'room', 'floors', 'enjoying', 'the', 'sun']]
```

**The final method**, which I've commited is:
```
nlp = spacy.blank("en")
nlp.add_pipe("lemmatizer", config={"mode": "lookup"})
nlp.initialize()
output= [[token.lemma_.lower() for token in doc] for doc in nlp.pipe(X)]
```
gives:
```
[['the', 'cat', 'sit', 'on', 'the', 'sit', 'room', 'floor', 'enjoy', 'the', 'sun']]
```



Checklist
---

- [ ] Added link to Github issue or Trello card
- [ ] Added tests
