### PR TITLE
Import umap during init and if needed

### DIFF
--- a/wellcomeml/ml/clustering.py
+++ b/wellcomeml/ml/clustering.py
@@ -22,7 +22,6 @@ except (ValueError, ModuleNotFoundError):
         "pip3 install hdbscan --no-cache-dir --no-binary :all: --no-build-isolation "
         "Read more https://github.com/wellcometrust/WellcomeML/issues/197"
     )
-import umap
 
 CACHE_DIR = os.path.expanduser("~/.cache/wellcomeml")
 
@@ -79,9 +78,12 @@ class TextClustering(object):
         self.cluster_reduced = cluster_reduced
 
         reducer_dispatcher = {
-            'umap': umap.UMAP,
             'tsne': TSNE
         }
+        if reducer == "umap":
+            # this imports takes 10-20s https://github.com/lmcinnes/umap/issues/631
+            import umap
+            reducer_dispatcher["umap"] = umap.UMAP
         self.reducer = reducer
         self.reducer_class = reducer_dispatcher[reducer](
             **params.get('reducer', {})


### PR DESCRIPTION
Description
---

Apparently what the source of the slowdown of `wellcomeml.ml`
is umap, see screenshot below and https://github.com/lmcinnes/umap/issues/631

As such this PR moves the import inside clustering init and
only when the user selects to use umap. This improves import time
from ~30s to ~10s in my laptop.

![Screenshot 2021-04-28 at 11 43 22 AM](https://user-images.githubusercontent.com/4975761/116374445-f4847380-a816-11eb-9fe0-d4d4a7fbc3fc.png)
Note that `wellcomeml.ml.frequency_vectorizer` seems to take time but I think this is an error. In case of interest the tool used is https://github.com/nschloe/tuna

Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests
