### PR TITLE
Fix OOM error during CNN predict

### DIFF
--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -268,10 +268,10 @@ def test_XY_dataset_sparse_y():
     vec = KerasVectorizer()
     X_vec = vec.fit_transform(X)
 
-    data = tf.data.Dataset.from_tensor_slices((X_vec, Y))
-    data = data.shuffle(100, seed=42)
+    train_data = tf.data.Dataset.from_tensor_slices((X_vec, Y))
+    test_data = tf.data.Dataset.from_tensor_slices((X_vec))
     clf = CNNClassifier(
         batch_size=2, sparse_y=True, multilabel=True
     )
-    clf.fit(data)
-    assert clf.score(data, Y_sparse) > 0.3
+    clf.fit(train_data)
+    assert clf.score(test_data, Y_sparse) > 0.3

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -317,7 +317,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
                     X_batch = X[i: i+self.batch_size]
                     yield X_batch
             else:  # tensorflow dataset
-                yield X
+                yield from X
 
         if self.sparse_y:
             Y_pred = []


### PR DESCRIPTION
Description
---

Fixes #297 

Tensorflow dataset is already an iterator so to yield elements we would have to do
```
from X_batch in X:
    yield X_batch
```

python `from` is equivalent to the above syntax.

Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests