### PR TITLE
Add pip freeze after tox so we can see all dependencies installed by tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ env:
     - DISABLE_DIRECT_IMPORTS=1
 
 script:
-  - pip freeze
   - tox
+  - pip freeze
 
 cache: pip
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
             'torch'
         ],
         'spacy': [
-            'spacy[lookups]<4.0.0,>=3.0.0'
+            'spacy[lookups]<3.1.0,>=3.0.0'
         ]
     },
     tests_require=[


### PR DESCRIPTION
Description
---

Fixes #311. Spacy 3.1.0 caused problems with the entity linking pipeline. In any case we're better off pinning Spacy anyway.

Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests
