### PR TITLE
Extend tokenizers to accomodate shap text explainer

### DIFF
--- a/tests/test_keras_vectorizer.py
+++ b/tests/test_keras_vectorizer.py
@@ -1,7 +1,20 @@
 import tempfile
 import os
 
-from wellcomeml.ml.keras_vectorizer import KerasVectorizer
+import pytest
+
+from wellcomeml.ml.keras_vectorizer import KerasVectorizer, KerasTokenizer
+
+
+@pytest.fixture
+def tokenizer():
+    tokenizer = KerasTokenizer()
+    tokenizer.fit([
+        "This is a test",
+        "Another sentence",
+        "Don't split"
+    ])
+    return tokenizer
 
 
 def test_vanilla():
@@ -84,3 +97,15 @@ def test_infer_from_data():
     keras_vectorizer.fit(X)
 
     assert keras_vectorizer.sequence_length == 3
+
+
+def test_keras_tokenizer_decode(tokenizer):
+    token_ids = tokenizer.encode("This is a test")
+    text = tokenizer.decode(token_ids)
+    assert text == "this is a test"
+
+
+def test_keras_tokenizer_decode_batch(tokenizer):
+    token_ids = tokenizer.encode(["This is", "a test"])
+    texts = tokenizer.decode(token_ids)
+    assert texts == ["this is", "a test"]

--- a/tests/test_keras_vectorizer.py
+++ b/tests/test_keras_vectorizer.py
@@ -109,3 +109,7 @@ def test_keras_tokenizer_decode_batch(tokenizer):
     token_ids = tokenizer.encode(["This is", "a test"])
     texts = tokenizer.decode(token_ids)
     assert texts == ["this is", "a test"]
+
+
+def test_keras_tokenizer_decode_empty(tokenizer):
+    assert tokenizer.decode([]) == ""

--- a/tests/test_transformers_tokenizer.py
+++ b/tests/test_transformers_tokenizer.py
@@ -61,6 +61,10 @@ def test_decode_batch(tokenizer):
     assert texts == ["this is a test", "test"]
 
 
+def test_decode_empty(tokenizer):
+    assert tokenizer.decode([]) == ""
+
+
 def test_unknown_token(tokenizer):
     tokens = tokenizer.tokenize("I have not seen this before")
     assert "[UNK]" in tokens

--- a/tests/test_transformers_tokenizer.py
+++ b/tests/test_transformers_tokenizer.py
@@ -49,6 +49,18 @@ def test_encode_batch(tokenizer):
     assert len(token_ids) == 2
 
 
+def test_decode(tokenizer):
+    token_ids = tokenizer.encode("This is a test")
+    text = tokenizer.decode(token_ids)
+    assert text == "this is a test"
+
+
+def test_decode_batch(tokenizer):
+    token_ids = tokenizer.encode(["This is a test", "test"])
+    texts = tokenizer.decode(token_ids)
+    assert texts == ["this is a test", "test"]
+
+
 def test_unknown_token(tokenizer):
     tokens = tokenizer.tokenize("I have not seen this before")
     assert "[UNK]" in tokens

--- a/wellcomeml/ml/keras_vectorizer.py
+++ b/wellcomeml/ml/keras_vectorizer.py
@@ -41,6 +41,8 @@ class KerasTokenizer():
         return self.tokenizer.texts_to_sequences(text)
 
     def decode(self, encoded_text):
+        if not encoded_text:
+            return ""
         if type(encoded_text[0]) == int:
             return self.tokenizer.sequences_to_texts([encoded_text])[0]
         return self.tokenizer.sequences_to_texts(encoded_text)

--- a/wellcomeml/ml/keras_vectorizer.py
+++ b/wellcomeml/ml/keras_vectorizer.py
@@ -35,8 +35,15 @@ class KerasTokenizer():
         self.tokenizer = Tokenizer(num_words=self.vocab_size, oov_token=self.oov_token)
         self.tokenizer.fit_on_texts(texts)
 
-    def encode(self, texts):
-        return self.tokenizer.texts_to_sequences(texts)
+    def encode(self, text):
+        if type(text) == str:
+            return self.tokenizer.texts_to_sequences([text])[0]
+        return self.tokenizer.texts_to_sequences(text)
+
+    def decode(self, encoded_text):
+        if type(encoded_text[0]) == int:
+            return self.tokenizer.sequences_to_texts([encoded_text])[0]
+        return self.tokenizer.sequences_to_texts(encoded_text)
 
 
 class KerasVectorizer(BaseEstimator, TransformerMixin):

--- a/wellcomeml/ml/transformers_tokenizer.py
+++ b/wellcomeml/ml/transformers_tokenizer.py
@@ -109,6 +109,8 @@ class TransformersTokenizer:
             raise NotImplementedError
 
     def decode(self, encoded_text):
+        if not encoded_text:
+            return ""
         if type(encoded_text[0]) in [list, np.ndarray]:
             return self.tokenizer.decode_batch(encoded_text)
         return self.tokenizer.decode(encoded_text)

--- a/wellcomeml/ml/transformers_tokenizer.py
+++ b/wellcomeml/ml/transformers_tokenizer.py
@@ -109,7 +109,8 @@ class TransformersTokenizer:
             raise NotImplementedError
 
     def decode(self, encoded_text):
-        # Note that we currently only support decoding a single encoded sentence
+        if type(encoded_text[0]) in [list, np.ndarray]:
+            return self.tokenizer.decode_batch(encoded_text)
         return self.tokenizer.decode(encoded_text)
 
     def save(self, tokenizer_path):

--- a/wellcomeml/ml/transformers_tokenizer.py
+++ b/wellcomeml/ml/transformers_tokenizer.py
@@ -7,12 +7,13 @@ from tokenizers.normalizers import Lowercase, Sequence
 from tokenizers.trainers import BpeTrainer, WordPieceTrainer
 from tokenizers.pre_tokenizers import ByteLevel, Whitespace
 from tokenizers import Tokenizer
-
+import numpy as np
 
 # TODO
 # - generalise to two sentences
 # - prepare input for transformers
 # - pad and truncate to max length
+
 
 class TransformersTokenizer:
     def __init__(self, lowercase=True,
@@ -99,13 +100,17 @@ class TransformersTokenizer:
             raise NotImplementedError
 
     def encode(self, text):
-        if type(text) == list:
+        if type(text) in [list, np.ndarray]:
             return list(self._yield_tokens_or_encodings(text, return_type="encodings"))
         elif type(text) == str:
             encoding = self.tokenizer.encode(text)
             return encoding.ids
         else:
             raise NotImplementedError
+
+    def decode(self, encoded_text):
+        # Note that we currently only support decoding a single encoded sentence
+        return self.tokenizer.decode(encoded_text)
 
     def save(self, tokenizer_path):
         self.tokenizer.save(tokenizer_path)


### PR DESCRIPTION
Description
---

In order to use the text masker in SHAP a tokenizer needs to implement a certain API, see https://github.com/slundberg/shap/pull/2084

Our tokenisers mostly follow that API (as we created both the API and the tokenisers :p) but some changes are still required to be able to use them with SHAP. One missing method is the ability to decode a single or multiple encoded texts. Another is to accept numpy arrays and work on both lists and single text instances a feature that transformers tokenizer has but keras tokeniser does not have

Fixes #317
Fixes #316 

Checklist
---

- [x] Added link to Github issue or Trello card
- [x] Added tests
