### PR TITLE
Add tensorboard_log_path and verbose param to CNN

### DIFF
--- a/wellcomeml/ml/bert_semantic_equivalence.py
+++ b/wellcomeml/ml/bert_semantic_equivalence.py
@@ -11,7 +11,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.utils.validation import check_is_fitted
 from sklearn.exceptions import NotFittedError
 
-from wellcomeml.ml.keras_utils import CategoricalMetrics, MetricMiniBatchHistory
+from wellcomeml.ml.keras_utils import CategoricalMetrics  # , MetricMiniBatchHistory
 from wellcomeml.logger import LOGGING_LEVEL, build_logger
 from wellcomeml.utils import throw_extra_import_message
 

--- a/wellcomeml/ml/bert_semantic_equivalence.py
+++ b/wellcomeml/ml/bert_semantic_equivalence.py
@@ -44,7 +44,8 @@ class SemanticEquivalenceClassifier(BaseEstimator, TransformerMixin):
         callbacks=['tensorboard'],
         random_seed=42,
         buffer_size=100,
-        logging_level=LOGGING_LEVEL
+        logging_level=LOGGING_LEVEL,
+        verbose=1  # follows Keras verbose for now
     ):
         """
 
@@ -71,6 +72,7 @@ class SemanticEquivalenceClassifier(BaseEstimator, TransformerMixin):
         self.callbacks = callbacks
         self.random_seed = random_seed
         self.buffer_size = buffer_size
+        self.verbose = verbose
 
         # Defines attributes that will be initialised later
         self.config = None
@@ -223,6 +225,7 @@ class SemanticEquivalenceClassifier(BaseEstimator, TransformerMixin):
                 validation_steps=self.valid_steps,
                 validation_data=self.valid_dataset,
                 callbacks=callback_objs,
+                verbose=self.verbose,
                 **kwargs
             )
 

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -52,7 +52,6 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         attention=False,
         attention_heads='same',
         metrics=["precision", "recall", "f1"],
-        callbacks=["tensorboard"],
         feature_approach="max",
         early_stopping=False,
         sparse_y=False,
@@ -80,7 +79,6 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         self.attention = attention
         self.attention_heads = attention_heads
         self.metrics = metrics
-        self.callbacks = callbacks
         self.feature_approach = feature_approach
         self.early_stopping = early_stopping
         self.sparse_y = sparse_y


### PR DESCRIPTION
Description
---

Add two params in CNN
* verbose
* tensorboard_log_path to control where logs are written

For more information on verbose see #328 

Tensorboard logs were written by default to "logs" in working
directory where the code was running. SageMaker provides functionality
for copying those logs to s3 which can allow us to monitor progress
locally by running tensorboard and point to the s3 path. For this functionality
to work we need to be able where logs are written so that sagemaker can
pick them up.

Fixes #328 

Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests
