### PR TITLE
Add tokenize to KerasTokenizer

### DIFF
--- a/wellcomeml/ml/keras_vectorizer.py
+++ b/wellcomeml/ml/keras_vectorizer.py
@@ -47,6 +47,12 @@ class KerasTokenizer():
             return self.tokenizer.sequences_to_texts([encoded_text])[0]
         return self.tokenizer.sequences_to_texts(encoded_text)
 
+    def tokenize(self, text):
+        if type(text) == str:
+            return text.split()
+        else:
+            return [t.split() for t in text]
+
 
 class KerasVectorizer(BaseEstimator, TransformerMixin):
     def __init__(self, vocab_size=None, sequence_length=None, oov_token="<OOV>",


### PR DESCRIPTION
Description
---

As explained in #340, i forgot to add a tokenize method in `KerasTokenizer` during #315. As
I am using `TransformersTokenizer` in the latest models, this was missed but this PR adds it
for consistency and so that `KerasTokenizer` works with `SHAP`

Fixes #340

Checklist
---

- [x] Added link to Github issue or Trello card
- [x] Added tests
