### PR TITLE
Do not initialize model if it exists in CNN

### DIFF
--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -317,3 +317,44 @@ def test_multilabel_attention():
     ])
     model.fit(X, Y)
     assert model.score(X, Y) > 0.3
+
+
+def test_build_model():
+    X = [
+        "One and two",
+        "One only",
+        "Two nothing else",
+        "Two and three"
+    ]
+    Y = np.array([
+        [1, 1, 0, 0],
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 1, 1, 0]
+    ])
+
+    vectorizer = KerasVectorizer()
+    X_vec = vectorizer.fit_transform(X)
+
+    batch_size = 2
+    model = CNNClassifier(
+        batch_size=batch_size,
+        multilabel=True, learning_rate=1e-2)
+    model.fit(X_vec, Y)
+
+    Y_pred = model.predict(X_vec)
+    assert Y_pred.shape[1] == 4
+
+    Y = Y[:, :3]
+    sequence_length = X_vec.shape[1]
+    vocab_size = X_vec.max() + 1
+    nb_outputs = Y.shape[1]
+    decay_steps = X_vec.shape[0] / batch_size
+
+    model.build_model(
+        sequence_length, vocab_size,
+        nb_outputs, decay_steps)
+    model.fit(X_vec, Y)
+
+    Y_pred = model.predict(X_vec)
+    assert Y_pred.shape[1] == 3

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -161,8 +161,8 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         )
         return steps_per_epoch
 
-    def _build_model(self, sequence_length, vocab_size, nb_outputs,
-                     steps_per_epoch, embedding_matrix=None):
+    def build_model(self, sequence_length, vocab_size, nb_outputs,
+                    decay_steps, embedding_matrix=None):
         def residual_conv_block(x1, l2):
             filters = x1.shape[2]
             x2 = tf.keras.layers.Conv1D(
@@ -251,10 +251,10 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         if self.feature_approach == "multilabel-attention":
             # out shape is (batch_size, attention heads (or outputs), 1)
             out = tf.keras.layers.Flatten()(out)
-        model = tf.keras.Model(inp, out)
+        self.model = tf.keras.Model(inp, out)
 
         learning_rate = tf.keras.optimizers.schedules.ExponentialDecay(
-            self.learning_rate, steps_per_epoch, self.learning_rate_decay,
+            self.learning_rate, decay_steps, self.learning_rate_decay,
             staircase=True
         )
 
@@ -267,8 +267,8 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
             METRIC_DICT[m] if m in METRIC_DICT else m
             for m in self.metrics
         ]
-        model.compile(optimizer=optimizer, loss="binary_crossentropy", metrics=metrics)
-        return model
+        self.model.compile(optimizer=optimizer, loss="binary_crossentropy", metrics=metrics)
+        return self.model
 
     def fit(self, X, Y=None, embedding_matrix=None, steps_per_epoch=None):
         if isinstance(X, list):
@@ -303,7 +303,7 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         else:
             strategy = self._get_distributed_strategy()
             with strategy.scope():
-                self.model = self._build_model(
+                self.build_model(
                     self.sequence_length, self.vocab_size, self.nb_outputs,
                     steps_per_epoch, embedding_matrix)
 

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -297,11 +297,15 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
         train_data = data.take(steps_per_epoch)
         val_data = data.skip(steps_per_epoch)
 
-        strategy = self._get_distributed_strategy()
-        with strategy.scope():
-            self.model = self._build_model(
-                self.sequence_length, self.vocab_size, self.nb_outputs,
-                steps_per_epoch, embedding_matrix)
+        if hasattr(self, "model"):
+            logger.warning("Using existing model")
+            print("Using existing model")
+        else:
+            strategy = self._get_distributed_strategy()
+            with strategy.scope():
+                self.model = self._build_model(
+                    self.sequence_length, self.vocab_size, self.nb_outputs,
+                    steps_per_epoch, embedding_matrix)
 
         callbacks = []
         if self.tensorboard_log_path:

--- a/wellcomeml/ml/cnn.py
+++ b/wellcomeml/ml/cnn.py
@@ -299,7 +299,6 @@ class CNNClassifier(BaseEstimator, ClassifierMixin):
 
         if hasattr(self, "model"):
             logger.warning("Using existing model")
-            print("Using existing model")
         else:
             strategy = self._get_distributed_strategy()
             with strategy.scope():


### PR DESCRIPTION
Description
---

The rational here is to allow to build a model that powers `CNNClassifier` without a call to fit. The use case is a particular experiment I want to run which performs training on a subset of labels and then keeps all layers but the last and continues training with more labels as a warm up strategy. To do that, I need a way to build the model with more outputs before copying the weights from the trained model.

Maybe a better way would be to pass the weight layers in `fit` and use them for initialisation. What do you think @aCampello @ivyleavedtoadflax ? In any case, this definitely allows me to run the experiment for now but keen to hear what you think would be the best way to express this

Checklist
---

- [ ] Added link to Github issue or Trello card
- [x] Added tests
