### PR TITLE
Replace trello with Notion in PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,5 +4,5 @@ Description
 Checklist
 ---
 
-- [ ] Added link to Github issue or Trello card
+- [ ] Added link to Github issue or Notion card
 - [ ] Added tests


### PR DESCRIPTION
Description
---

Since we are using Notion instead of Trello, i updated
the PR template to reflect that.

Checklist
---

- [ ] Added link to Github issue or Notion card
- [ ] Added tests
