### PR TITLE
Fix write_jsonl docstring to call for list of dicts

### DIFF
--- a/wellcomeml/io/io.py
+++ b/wellcomeml/io/io.py
@@ -50,7 +50,7 @@ def _yield_jsonl(file_name):
 
 
 def read_jsonl(input_file):
-    """Create a list from a jsonl file
+    """Create a list of dicts from a jsonl file
 
     Args:
         input_file(str): File to be loaded.


### PR DESCRIPTION
Description
---

Liz stumbled into what seemed like a bug some time
ago but was a not clear docstring problem for `write_jsonl`.

This PR updates the docstring to make the usage clearer

Fixes #58

Checklist
---

- [x] Added link to Github issue or Trello card
- [ ] Added tests
