### PR TITLE
Investigate why codecov breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![PyPI](https://img.shields.io/pypi/v/wellcomeml)
 [![docs](https://img.shields.io/badge/docs-%20-success)](http://wellcometrust.github.io/WellcomeML)
 
-
 # WellcomeML utils
 
 This package contains common utility functions for usual tasks at the Wellcome Trust, in particular functionalities for processing, embedding and classifying text data. This includes


### PR DESCRIPTION
Description
---

This is an investigation of #310. The theory is that codecov breaks when we mess up with commit hashes somehow. One way this can happen is if a PR is behind main and we merge using rebase and squash. This would alter the commit hash without running tests or codecov so the report for main will be missing.

This PR dropped some commits from main and made a simple change. The goal is to merge with `rebase and squash` and then open another PR to test whether `codecov` is broken. If it is, I suspect that merging the new PR will fix that as the tests and codecov would run for that.

Checklist
---

- [ ] Added link to Github issue or Trello card
- [ ] Added tests
