### PR TITLE
Unpin tokenizers to update transformers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras = {
         ],
         'transformers': [
             'transformers',
-            'tokenizers==0.10.1'
+            'tokenizers'
         ],
         'tensorflow': [
             'tensorflow==2.4.0',


### PR DESCRIPTION
Description
---

I am keen to get the latest version of transformers to use it in grants tagger for uploading BertMesh to the hub. They have simplified the way to do that in their last release see https://huggingface.co/docs/transformers/master/en/custom_models#sending-the-code-to-the-hub. Our pin of tokenisers is keeping transformers from getting that release in projects that use WellcomeML. The pin was introduced for the opposite reason which was to ensure that we get at least that version which was needed for TransformersTokenizer.

Checklist
---

- [ ] Added link to Github issue or Notion card
- [ ] Added tests
