### PR TITLE
Feature/nice heatmap

### DIFF
--- a/examples/heatmap.py
+++ b/examples/heatmap.py
@@ -1,0 +1,18 @@
+from wellcomeml.viz.elements import plot_heatmap
+
+# Fake co_occurrence matrix of the concepts "Data Science", "Machine Learning" and "Science"
+
+co_occurrence = [
+   {"concept_1": "Data Science", "concept_2": "Machine Learning", "value": 1},
+   {"concept_1": "Machine Learning", "concept_2": "Data Science", "value": 0.3},
+   {"concept_1": "Science", "concept_2": "Data Science", "value": 1},
+   {"concept_1": "Science", "concept_2": "Machine Learning", "value": 1},
+   {"concept_1": "Data Science", "concept_2": "Science", "value": 0.05},
+   {"concept_1": "Machine Learning", "concept_2": "Science", "value": 0.01}
+]
+
+# Plot in blue
+plot_heatmap(co_occurrence, file='test-blue.html', color="Blue Lagoon")
+
+# Plot in gold
+plot_heatmap(co_occurrence, file='test-gold.html', color="Tahiti Gold")

--- a/examples/heatmap.py
+++ b/examples/heatmap.py
@@ -3,16 +3,18 @@ from wellcomeml.viz.elements import plot_heatmap
 # Fake co_occurrence matrix of the concepts "Data Science", "Machine Learning" and "Science"
 
 co_occurrence = [
-   {"concept_1": "Data Science", "concept_2": "Machine Learning", "value": 1},
-   {"concept_1": "Machine Learning", "concept_2": "Data Science", "value": 0.3},
-   {"concept_1": "Science", "concept_2": "Data Science", "value": 1},
-   {"concept_1": "Science", "concept_2": "Machine Learning", "value": 1},
-   {"concept_1": "Data Science", "concept_2": "Science", "value": 0.05},
-   {"concept_1": "Machine Learning", "concept_2": "Science", "value": 0.01}
+   {"concept_1": "Data Science", "concept_2": "Machine Learning", "value": 1, "abbr": "DS/ML"},
+   {"concept_1": "Machine Learning", "concept_2": "Data Science", "value": 0.3, "abbr": "ML/DS"},
+   {"concept_1": "Science", "concept_2": "Data Science", "value": 1, "abbr": "S/DS"},
+   {"concept_1": "Science", "concept_2": "Machine Learning", "value": 1, "abbr": "S/ML"},
+   {"concept_1": "Data Science", "concept_2": "Science", "value": 0.05, "abbr": "DS/S"},
+   {"concept_1": "Machine Learning", "concept_2": "Science", "value": 0.01, "abbr": "ML/S"}
 ]
 
 # Plot in blue
-plot_heatmap(co_occurrence, file='test-blue.html', color="Blue Lagoon")
+plot_heatmap(co_occurrence, file='test-blue.html', color="Blue Lagoon",
+             metadata_to_display=[("Abbreviation", "abbr")])
 
 # Plot in gold
-plot_heatmap(co_occurrence, file='test-gold.html', color="Tahiti Gold")
+plot_heatmap(co_occurrence, file='test-gold.html', color="Tahiti Gold",
+             metadata_to_display=[("Abbreviation", "abbr")])

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras = {
             'scikit-learn',
             'scipy',
             'umap-learn',
-            'gensim<=4.0.0',
+            'gensim',
             'bokeh',
             'pandas',
             'nervaluate'

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -7,7 +7,8 @@ def test_heatmap(tmp_path):
 
     co_occurrence = [
        {"concept_1": "Data Science", "concept_2": "Machine Learning", "value": 1, "abbr": "DS/ML"},
-       {"concept_1": "Machine Learning", "concept_2": "Data Science", "value": 0.3, "abbr": "ML/DS"},
+       {"concept_1": "Machine Learning", "concept_2": "Data Science", "value": 0.3,
+        "abbr": "ML/DS"},
        {"concept_1": "Science", "concept_2": "Data Science", "value": 1, "abbr": "S/DS"},
        {"concept_1": "Science", "concept_2": "Machine Learning", "value": 1, "abbr": "S/ML"},
        {"concept_1": "Data Science", "concept_2": "Science", "value": 0.05, "abbr": "DS/S"},
@@ -22,4 +23,3 @@ def test_heatmap(tmp_path):
 
     # Asserts that it created the file correctly.
     assert os.path.exists(path)
-

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -1,0 +1,25 @@
+import os
+
+from wellcomeml.viz.elements import plot_heatmap
+
+
+def test_heatmap(tmp_path):
+
+    co_occurrence = [
+       {"concept_1": "Data Science", "concept_2": "Machine Learning", "value": 1, "abbr": "DS/ML"},
+       {"concept_1": "Machine Learning", "concept_2": "Data Science", "value": 0.3, "abbr": "ML/DS"},
+       {"concept_1": "Science", "concept_2": "Data Science", "value": 1, "abbr": "S/DS"},
+       {"concept_1": "Science", "concept_2": "Machine Learning", "value": 1, "abbr": "S/ML"},
+       {"concept_1": "Data Science", "concept_2": "Science", "value": 0.05, "abbr": "DS/S"},
+       {"concept_1": "Machine Learning", "concept_2": "Science", "value": 0.01, "abbr": "ML/S"}
+    ]
+
+    # Plot in blue
+    path = os.path.join(tmp_path, 'test.html')
+
+    plot_heatmap(co_occurrence, file=path, color="Blue Lagoon",
+                 metadata_to_display=[("Abbreviation", "abbr")])
+
+    # Asserts that it created the file correctly.
+    assert os.path.exists(path)
+

--- a/wellcomeml/viz/elements.py
+++ b/wellcomeml/viz/elements.py
@@ -18,7 +18,9 @@ def plot_heatmap(co_occurrence,
                  title="",
                  notebook_url='localhost:8888',
                  color='Blue Lagoon',
-                 metadata_to_display=[]):
+                 metadata_to_display=[],
+                 rectangle_size=0.9,
+                 display_percentages=True):
     """
     Plots a nice bokeh heatmap between two sets of "concepts" using the Wellcome pallette.
 
@@ -42,6 +44,8 @@ def plot_heatmap(co_occurrence,
         metadata_to_display(list): List of 2-uples describing the legend and the key to display
           Exmaple, if the co_ocurrence matrix consist of the keys `concept_1`, `concept_2`,
           `value`, `legend`, one can send `metadata_to_display=[(This is a legend, legend)]`
+        rectangle_size(int): Size of the rectangles to plot. Default: 0.9
+        display_percentages(bool): Whether to show the percentages in the each rectangle as text
 
     Returns:
     """
@@ -93,14 +97,16 @@ def plot_heatmap(co_occurrence,
     else:
         y_range = np.unique(y_names)
 
-    labels = LabelSet(x='x_name', y='y_name', text='alpha_text', text_font_size='16px',
-                      text_align="center", source=data, render_mode='canvas')
-
     p = figure(title=title, x_axis_location="below", tools=tools,
                x_range=x_range,
                y_range=y_range,
                tooltips=tooltips,
                background_fill_color=str(WellcomeBackground))
+
+    if display_percentages:
+        labels = LabelSet(x='x_name', y='y_name', text='alpha_text', text_font_size='16px',
+                          text_align="center", source=data, render_mode='canvas')
+        p.add_layout(labels)
 
     p.plot_width = 1000
     p.plot_height = 1000
@@ -110,7 +116,7 @@ def plot_heatmap(co_occurrence,
     p.axis.major_label_text_font_size = "8pt"
     p.xaxis.major_label_orientation = np.pi / 3
 
-    p.rect('x_name', 'y_name', 0.9, 0.9, source=data,
+    p.rect('x_name', 'y_name', rectangle_size, rectangle_size, source=data,
            color='colors', alpha='alphas', line_color=None,
            hover_line_color='black', hover_color='colors')
 
@@ -118,7 +124,5 @@ def plot_heatmap(co_occurrence,
         output_notebook()
     if file:
         output_file(file, title=title)
-
-    p.add_layout(labels)
 
     show(p, notebook_url=notebook_url)

--- a/wellcomeml/viz/elements.py
+++ b/wellcomeml/viz/elements.py
@@ -1,11 +1,10 @@
 from collections import defaultdict
 
 import numpy as np
-from bokeh.plotting import ColumnDataSource, figure, show
-from bokeh.io import curdoc, \
-    output_notebook, output_file, export_png, reset_output
+from bokeh.plotting import figure, show
+from bokeh.io import output_notebook, output_file, reset_output
 
-from wellcomeml.viz.palettes import WellcomeBackground, WellcomeNoData
+from wellcomeml.viz.palettes import WellcomeBackground
 from wellcomeml.viz.colors import NAMED_COLORS_DICT
 
 
@@ -33,7 +32,8 @@ def plot_heatmap(co_occurrence,
             {"concept_1": banana, "concept_2": fruit, "value": 0.1}
         ]
 
-        concept_order(list): A list of order of concepts to plot, if none will chose arbitrary
+        concept_order(list): A list of order of concepts to plot, if none will chose arbitrary.
+          Only applicable if list of "concepts_1" is the same as "concepts_2"
         file(str): A file to save the output
         color(str): Which color from the Wellcome pallete (see `wellcomeml.viz.colors`)
         metadata_to_display(list): List of 2-uples describing the legend and the key to display
@@ -71,7 +71,6 @@ def plot_heatmap(co_occurrence,
 
     data = {**data, **metadata}
 
-
     title = title
     tools = "hover,save,wheel_zoom"
     tooltips = [('Tags', '@y_name, @x_name'),
@@ -81,7 +80,13 @@ def plot_heatmap(co_occurrence,
         tooltips += [(legend, '@' + key) for legend, key in metadata_to_display]
 
     x_range = (concept_order if concept_order else list(reversed(np.unique(x_names))))
-    y_range = list(reversed(concept_order))
+    # If the concepts are equal in rows and columns plot them in order, otherwise
+    # just plot the unique y_concepts
+    if set(x_names) == set(y_names):
+        y_range = list(reversed(x_range))
+    else:
+        y_range = np.unique(y_names)
+
     p = figure(title=title, x_axis_location="below", tools=tools,
                x_range=x_range,
                y_range=y_range,

--- a/wellcomeml/viz/elements.py
+++ b/wellcomeml/viz/elements.py
@@ -9,7 +9,6 @@ from bokeh.models import LabelSet, ColumnDataSource
 from wellcomeml.viz.palettes import WellcomeBackground
 from wellcomeml.viz.colors import NAMED_COLORS_DICT
 
-A = 'test'
 
 def plot_heatmap(co_occurrence,
                  concept_order=None,

--- a/wellcomeml/viz/elements.py
+++ b/wellcomeml/viz/elements.py
@@ -1,0 +1,108 @@
+from collections import defaultdict
+
+import numpy as np
+from bokeh.plotting import ColumnDataSource, figure, show
+from bokeh.io import curdoc, \
+    output_notebook, output_file, export_png, reset_output
+
+from wellcomeml.viz.palettes import WellcomeBackground, WellcomeNoData
+from wellcomeml.viz.colors import NAMED_COLORS_DICT
+
+
+def plot_heatmap(co_occurrence,
+                 concept_order=None,
+                 file="heatmap.html",
+                 notebook=True,
+                 title="",
+                 notebook_url='localhost:8888',
+                 color='Blue Lagoon',
+                 metadata_to_display=[]):
+    """
+    Plots a nice bokeh heatmap between two sets of "concepts" using the Wellcome pallette.
+
+
+    Args:
+        co_occurrence(list): list of dictionaries containing, at least:
+        "concept_1", "concept_2", and the value of the edge, between 0 and 1.
+
+        For example:
+
+        co_ocurrence = [
+            {"concept_1": apple, "concept_2": fruit, "value": 0.2},
+            {"concept_1": apple, "concept_2": vegetable, "value": 0.1},
+            {"concept_1": banana, "concept_2": fruit, "value": 0.1}
+        ]
+
+        concept_order(list): A list of order of concepts to plot, if none will chose arbitrary
+        file(str): A file to save the output
+        color(str): Which color from the Wellcome pallete (see `wellcomeml.viz.colors`)
+        metadata_to_display(list): List of 2-uples describing the legend and the key to display
+          Exmaple, if the co_ocurrence matrix consist of the keys `concept_1`, `concept_2`,
+          `value`, `legend`, one can send `metadata_to_display=[(This is a legend, legend)]`
+
+    Returns:
+    """
+    reset_output()
+
+    x_names = []
+    y_names = []
+    alphas = []
+    colors = []
+    metadata = defaultdict(list)
+
+    for row in co_occurrence:
+        x_names.append(row['concept_1'])
+        y_names.append(row['concept_2'])
+        alphas.append(row['value'])
+
+        for key, value in row.items():
+            if key != ['concept_1', 'concept_2', 'concept_2']:
+                metadata[key].append(value)
+
+        colors.append(str(NAMED_COLORS_DICT[color]))
+
+    data = {
+        "x_name": x_names,
+        "y_name": y_names,
+        "alphas": alphas,
+        "alpha_percentage": [100*alpha for alpha in alphas],
+        "colors": colors
+    }
+
+    data = {**data, **metadata}
+
+
+    title = title
+    tools = "hover,save,wheel_zoom"
+    tooltips = [('Tags', '@y_name, @x_name'),
+                ('Co-Ocurrence (percentage)', '@alpha_percentage')]
+
+    if metadata_to_display:
+        tooltips += [(legend, '@' + key) for legend, key in metadata_to_display]
+
+    x_range = (concept_order if concept_order else list(reversed(np.unique(x_names))))
+    y_range = list(reversed(concept_order))
+    p = figure(title=title, x_axis_location="below", tools=tools,
+               x_range=x_range,
+               y_range=y_range,
+               tooltips=tooltips,
+               background_fill_color=str(WellcomeBackground))
+
+    p.plot_width = 1000
+    p.plot_height = 1000
+    p.grid.grid_line_color = None
+    p.axis.axis_line_color = None
+    p.axis.major_tick_line_color = None
+    p.axis.major_label_text_font_size = "8pt"
+    p.xaxis.major_label_orientation = np.pi / 3
+
+    p.rect('x_name', 'y_name', 0.9, 0.9, source=data,
+           color='colors', alpha='alphas', line_color=None,
+           hover_line_color='black', hover_color='colors')
+
+    if notebook:
+        output_notebook()
+    if file:
+        output_file(file, title=title)
+
+    show(p, notebook_url=notebook_url)

--- a/wellcomeml/viz/elements.py
+++ b/wellcomeml/viz/elements.py
@@ -3,10 +3,13 @@ from collections import defaultdict
 import numpy as np
 from bokeh.plotting import figure, show
 from bokeh.io import output_notebook, output_file, reset_output
+from bokeh.models import LabelSet, ColumnDataSource
+
 
 from wellcomeml.viz.palettes import WellcomeBackground
 from wellcomeml.viz.colors import NAMED_COLORS_DICT
 
+A = 'test'
 
 def plot_heatmap(co_occurrence,
                  concept_order=None,
@@ -66,10 +69,13 @@ def plot_heatmap(co_occurrence,
         "y_name": y_names,
         "alphas": alphas,
         "alpha_percentage": [100*alpha for alpha in alphas],
+        "alpha_text": [f'{100*alpha:.0f}%' for alpha in alphas],
         "colors": colors
     }
 
     data = {**data, **metadata}
+
+    data = ColumnDataSource(data=data)
 
     title = title
     tools = "hover,save,wheel_zoom"
@@ -86,6 +92,9 @@ def plot_heatmap(co_occurrence,
         y_range = list(reversed(x_range))
     else:
         y_range = np.unique(y_names)
+
+    labels = LabelSet(x='x_name', y='y_name', text='alpha_text', text_font_size='16px',
+                      text_align="center", source=data, render_mode='canvas')
 
     p = figure(title=title, x_axis_location="below", tools=tools,
                x_range=x_range,
@@ -109,5 +118,7 @@ def plot_heatmap(co_occurrence,
         output_notebook()
     if file:
         output_file(file, title=title)
+
+    p.add_layout(labels)
 
     show(p, notebook_url=notebook_url)

--- a/wellcomeml/viz/elements.py
+++ b/wellcomeml/viz/elements.py
@@ -18,7 +18,7 @@ def plot_heatmap(co_occurrence,
                  title="",
                  notebook_url='localhost:8888',
                  color='Blue Lagoon',
-                 metadata_to_display=[],
+                 metadata_to_display=None,
                  rectangle_size=0.9,
                  display_percentages=True):
     """


### PR DESCRIPTION
Description
---

Creates an util to plot a beautiful and interactive co-ocurrence heatmap with the Wellcome palette and colours. Can be used for different use cases (e.g. confusion matrix, to inspect multilabel classification, to plot overlap between tags/areas), hence the idea of adding it to `wellcomeml`. The heatmap will look like the below:

![bokeh_plot-15](https://user-images.githubusercontent.com/27929341/162251355-c97ed462-57e5-4089-b829-60d94ea172c6.png)

